### PR TITLE
Feat/transfers staged rollout

### DIFF
--- a/.kiro/steering/ai-contribution-rules.md
+++ b/.kiro/steering/ai-contribution-rules.md
@@ -83,6 +83,14 @@ Run `yarn check:fix` before committing. The pre-commit hook runs Biome automatic
 
 All component styles use CSS Modules (`.module.css`). No inline styles, no global class names, no Tailwind. Shared design tokens live in `design-tokens.css`.
 
+### React component structure
+
+Do not define `renderSomething()` helpers inside React components. If a JSX section is large enough to name, extract it into a real component so React can treat it as part of the component tree and future memoization remains possible.
+
+Pure or near-pure helpers should live outside components and receive their dependencies as arguments. Keep component bodies focused on state, effects, event handlers, and composition.
+
+Use named constants for repeated string comparisons, especially UI state values such as steps, modes, and tabs. Avoid scattering magic strings through branch logic.
+
 ### React Router loaders own data fetching
 
 All server-side data fetching happens in React Router loader functions (`.route.tsx` files). Components do not fetch data directly on the server. Client-side re-fetching uses TanStack Query.

--- a/draft/app/transfers/components/transfer-form.module.css
+++ b/draft/app/transfers/components/transfer-form.module.css
@@ -1,5 +1,107 @@
 /* app/transfers/components/transfer-form.module.css */
 
+.journey {
+    display: flex;
+    flex-direction: column;
+    min-height: 60vh;
+    width: 100%;
+}
+
+.journeyHeader {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+    margin-bottom: var(--spacing-4);
+    padding-bottom: var(--spacing-3);
+    border-bottom: 1px solid var(--color-gray-200);
+}
+
+.journeyTitle {
+    font-size: var(--font-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+    margin: 0;
+}
+
+.backButton {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    color: var(--color-primary);
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    padding: var(--spacing-2) 0;
+    min-height: 44px;
+}
+
+.backButton:hover {
+    color: var(--color-primary-hover);
+}
+
+.stepContent {
+    flex: 1;
+    width: 100%;
+    min-width: 0;
+}
+
+.journeyFooter {
+    position: sticky;
+    bottom: 0;
+    padding: var(--spacing-4) 0;
+    background: var(--color-white);
+    border-top: 1px solid var(--color-gray-200);
+    margin-top: var(--spacing-4);
+}
+
+.continueButton {
+    width: 100%;
+    background: var(--color-primary);
+    color: var(--color-white);
+    border: none;
+    border-radius: var(--radius-md);
+    padding: var(--spacing-3) var(--spacing-6);
+    font-size: var(--font-base);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    min-height: 48px;
+    transition: background-color var(--transition-normal);
+}
+
+.continueButton:hover {
+    background: var(--color-primary-hover);
+}
+
+.reviewSummary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4);
+    background: var(--color-gray-50);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--spacing-4);
+}
+
+.reviewRow {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+}
+
+.reviewLabel {
+    font-size: var(--font-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-600);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.reviewValue {
+    font-size: var(--font-base);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-900);
+}
+
 .transferForm {
     background: var(--color-white);
     border: 1px solid var(--color-gray-200);

--- a/draft/app/transfers/components/transfer-form.module.css
+++ b/draft/app/transfers/components/transfer-form.module.css
@@ -48,10 +48,16 @@
 .journeyFooter {
     position: sticky;
     bottom: 0;
+    z-index: 20;
     padding: var(--spacing-4) 0;
     background: var(--color-white);
     border-top: 1px solid var(--color-gray-200);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.06);
     margin-top: var(--spacing-4);
+}
+
+.inlineTransferType {
+    margin-bottom: var(--spacing-4);
 }
 
 .continueButton {

--- a/draft/app/transfers/components/transfer-form.tsx
+++ b/draft/app/transfers/components/transfer-form.tsx
@@ -31,7 +31,7 @@ import { TransferTypeSelector } from './transfer-type-selector';
 
 export type JourneyPath = 'team-first' | 'player-list-first';
 
-type JourneyStep = 'first-selector' | 'transaction-type' | 'second-selector' | 'review';
+type JourneyStep = 'first-selector' | 'second-selector' | 'review';
 
 interface TransferFormProps {
     divisions: DivisionSheetData[];
@@ -80,10 +80,6 @@ const STEP_TITLES: Record<JourneyStep, Record<JourneyPath, string>> = {
         'team-first': 'Select player from your team',
         'player-list-first': 'Select player from list',
     },
-    'transaction-type': {
-        'team-first': 'Choose transaction type',
-        'player-list-first': 'Choose transaction type',
-    },
     'second-selector': {
         'team-first': 'Select player to bring in',
         'player-list-first': 'Select player to remove',
@@ -100,8 +96,6 @@ function canContinue(step: JourneyStep, journeyPath: JourneyPath, playerSelectio
             return journeyPath === 'team-first'
                 ? playerSelection.playerOut !== null
                 : playerSelection.playerIn !== null;
-        case 'transaction-type':
-            return true;
         case 'second-selector':
             return journeyPath === 'team-first'
                 ? playerSelection.playerIn !== null
@@ -149,6 +143,39 @@ export function TransferForm({
         return acc;
     }, {});
 
+    const getLoanSelectionForTransfer = (
+        nextTransferType: TransferType,
+        nextPlayerSelection: PlayerSelectionState,
+    ): LoanSelectionState => {
+        if (nextTransferType !== 'LOAN_START') {
+            return INITIAL_LOAN_SELECTION;
+        }
+
+        const playerIn = nextPlayerSelection.playerIn;
+        if (!playerIn) {
+            return INITIAL_LOAN_SELECTION;
+        }
+
+        const ownership = getPlayerOwnership(playerIn, ownedPlayersByCode);
+        if (ownership.ownerId && ownership.ownerId !== selectedManager) {
+            return {
+                loanPlayer: playerIn,
+                loanToManager: null,
+                loanFromManager: ownership.ownerId,
+            };
+        }
+
+        if (!ownership.ownerId && nextPlayerSelection.playerOut) {
+            return {
+                loanPlayer: nextPlayerSelection.playerOut,
+                loanToManager: null,
+                loanFromManager: null,
+            };
+        }
+
+        return INITIAL_LOAN_SELECTION;
+    };
+
     const clearForm = () => {
         setStep('first-selector');
         setTransferType('TRANSFER');
@@ -189,42 +216,28 @@ export function TransferForm({
     };
 
     const handlePlayerOutChange = (playerOut: RosterPlayer | null) => {
-        setPlayerSelection((prev) => ({
-            ...prev,
+        const nextPlayerSelection = {
+            ...playerSelection,
             playerOut,
-        }));
+        };
+
+        setPlayerSelection(nextPlayerSelection);
+        setLoanSelection(getLoanSelectionForTransfer(transferType, nextPlayerSelection));
     };
 
     const handlePlayerInChange = (playerIn: EnhancedPlayerData | null) => {
-        setPlayerSelection((prev) => ({
-            ...prev,
+        const nextPlayerSelection = {
+            ...playerSelection,
             playerIn,
-        }));
+        };
 
-        if (playerIn && transferType === 'LOAN_START') {
-            const ownership = getPlayerOwnership(playerIn, ownedPlayersByCode);
-            if (ownership.ownerId && ownership.ownerId !== selectedManager) {
-                setLoanSelection({
-                    loanPlayer: playerIn,
-                    loanToManager: null,
-                    loanFromManager: ownership.ownerId,
-                });
-            } else if (!ownership.ownerId) {
-                setLoanSelection({
-                    loanPlayer: playerSelection.playerOut,
-                    loanToManager: null,
-                    loanFromManager: null,
-                });
-            }
-        }
+        setPlayerSelection(nextPlayerSelection);
+        setLoanSelection(getLoanSelectionForTransfer(transferType, nextPlayerSelection));
     };
 
     const handleTransferTypeChange = (nextTransferType: TransferType) => {
         setTransferType(nextTransferType);
-
-        if (nextTransferType !== 'LOAN_START' && nextTransferType !== 'LOAN_END') {
-            setLoanSelection(INITIAL_LOAN_SELECTION);
-        }
+        setLoanSelection(getLoanSelectionForTransfer(nextTransferType, playerSelection));
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -264,12 +277,8 @@ export function TransferForm({
             onExit();
             return;
         }
-        if (step === 'transaction-type') {
-            setStep('first-selector');
-            return;
-        }
         if (step === 'second-selector') {
-            setStep('transaction-type');
+            setStep('first-selector');
             return;
         }
         setStep('second-selector');
@@ -277,10 +286,6 @@ export function TransferForm({
 
     const goForward = () => {
         if (step === 'first-selector') {
-            setStep('transaction-type');
-            return;
-        }
-        if (step === 'transaction-type') {
             setStep('second-selector');
             return;
         }
@@ -292,6 +297,7 @@ export function TransferForm({
     const isLoanTransfer = transferType === 'LOAN_START' || transferType === 'LOAN_END';
     const canSubmit = fetcher.state === 'submitting' || !playerSelection.playerOut || !playerSelection.playerIn;
     const showContinue = step !== 'review' && canContinue(step, journeyPath, playerSelection);
+    const showTransferTypeSelector = step === 'first-selector' && canContinue(step, journeyPath, playerSelection);
 
     const renderFirstSelector = () => {
         if (!selectedManager || !managerRoster) {
@@ -451,16 +457,19 @@ export function TransferForm({
 
             <form onSubmit={handleSubmit} className={styles.form}>
                 {step === 'first-selector' ? <div className={styles.stepContent}>{renderFirstSelector()}</div> : null}
-                {step === 'transaction-type' ? (
-                    <div className={styles.stepContent}>
-                        <TransferTypeSelector selectedType={transferType} onTypeChange={handleTransferTypeChange} />
-                    </div>
-                ) : null}
                 {step === 'second-selector' ? <div className={styles.stepContent}>{renderSecondSelector()}</div> : null}
                 {step === 'review' ? <div className={styles.stepContent}>{renderReview()}</div> : null}
 
                 {showContinue ? (
                     <div className={styles.journeyFooter}>
+                        {showTransferTypeSelector ? (
+                            <div className={styles.inlineTransferType}>
+                                <TransferTypeSelector
+                                    selectedType={transferType}
+                                    onTypeChange={handleTransferTypeChange}
+                                />
+                            </div>
+                        ) : null}
                         <button type="button" className={styles.continueButton} onClick={goForward}>
                             Continue
                         </button>

--- a/draft/app/transfers/components/transfer-form.tsx
+++ b/draft/app/transfers/components/transfer-form.tsx
@@ -20,7 +20,12 @@ import type {
     UserTeamsSheetData,
 } from '../../teams/types/team-types';
 import { getPlayerOwnership } from '../lib/get-player-ownership';
-import type { OwnedPlayersByCode, PlayerSelectionState, TransferValidationResult } from '../types/transfer-form-types';
+import type {
+    OwnedPlayersByCode,
+    PlayerEligibility,
+    PlayerSelectionState,
+    TransferValidationResult,
+} from '../types/transfer-form-types';
 import type { TransferRuleContext } from '../types/transfer-rule-types';
 import type { TransferType } from '../types/transfer-types';
 import { LoanInfoPanel } from './loan-info-panel';
@@ -29,9 +34,20 @@ import { PlayerOutSelector } from './player-out-selector';
 import styles from './transfer-form.module.css';
 import { TransferTypeSelector } from './transfer-type-selector';
 
-export type JourneyPath = 'team-first' | 'player-list-first';
+const JOURNEY_PATHS = {
+    teamFirst: 'team-first',
+    playerListFirst: 'player-list-first',
+} as const;
 
-type JourneyStep = 'first-selector' | 'second-selector' | 'review';
+export type JourneyPath = (typeof JOURNEY_PATHS)[keyof typeof JOURNEY_PATHS];
+
+const JOURNEY_STEPS = {
+    firstSelector: 'first-selector',
+    secondSelector: 'second-selector',
+    review: 'review',
+} as const;
+
+type JourneyStep = (typeof JOURNEY_STEPS)[keyof typeof JOURNEY_STEPS];
 
 interface TransferFormProps {
     divisions: DivisionSheetData[];
@@ -76,33 +92,294 @@ const INITIAL_VALIDATION: TransferValidationResult = {
 };
 
 const STEP_TITLES: Record<JourneyStep, Record<JourneyPath, string>> = {
-    'first-selector': {
-        'team-first': 'Select player from your team',
-        'player-list-first': 'Select player from list',
+    [JOURNEY_STEPS.firstSelector]: {
+        [JOURNEY_PATHS.teamFirst]: 'Select player from your team',
+        [JOURNEY_PATHS.playerListFirst]: 'Select player from list',
     },
-    'second-selector': {
-        'team-first': 'Select player to bring in',
-        'player-list-first': 'Select player to remove',
+    [JOURNEY_STEPS.secondSelector]: {
+        [JOURNEY_PATHS.teamFirst]: 'Select player to bring in',
+        [JOURNEY_PATHS.playerListFirst]: 'Select player to remove',
     },
-    review: {
-        'team-first': 'Review and submit',
-        'player-list-first': 'Review and submit',
+    [JOURNEY_STEPS.review]: {
+        [JOURNEY_PATHS.teamFirst]: 'Review and submit',
+        [JOURNEY_PATHS.playerListFirst]: 'Review and submit',
     },
 };
 
 function canContinue(step: JourneyStep, journeyPath: JourneyPath, playerSelection: PlayerSelectionState): boolean {
     switch (step) {
-        case 'first-selector':
-            return journeyPath === 'team-first'
+        case JOURNEY_STEPS.firstSelector:
+            return journeyPath === JOURNEY_PATHS.teamFirst
                 ? playerSelection.playerOut !== null
                 : playerSelection.playerIn !== null;
-        case 'second-selector':
-            return journeyPath === 'team-first'
+        case JOURNEY_STEPS.secondSelector:
+            return journeyPath === JOURNEY_PATHS.teamFirst
                 ? playerSelection.playerIn !== null
                 : playerSelection.playerOut !== null;
-        case 'review':
+        case JOURNEY_STEPS.review:
             return false;
     }
+}
+
+function getLoanSelectionForTransfer(
+    nextTransferType: TransferType,
+    nextPlayerSelection: PlayerSelectionState,
+    ownedPlayersByCode: OwnedPlayersByCode,
+    selectedManager: ManagerId,
+): LoanSelectionState {
+    if (nextTransferType !== 'LOAN_START') {
+        return INITIAL_LOAN_SELECTION;
+    }
+
+    const playerIn = nextPlayerSelection.playerIn;
+    if (!playerIn) {
+        return INITIAL_LOAN_SELECTION;
+    }
+
+    const ownership = getPlayerOwnership(playerIn, ownedPlayersByCode);
+    if (ownership.ownerId && ownership.ownerId !== selectedManager) {
+        return {
+            loanPlayer: playerIn,
+            loanToManager: null,
+            loanFromManager: ownership.ownerId,
+        };
+    }
+
+    if (!ownership.ownerId && nextPlayerSelection.playerOut) {
+        return {
+            loanPlayer: nextPlayerSelection.playerOut,
+            loanToManager: null,
+            loanFromManager: null,
+        };
+    }
+
+    return INITIAL_LOAN_SELECTION;
+}
+
+interface SelectorStepProps {
+    availablePlayers: EnhancedPlayerData[];
+    selectedManager: ManagerId;
+    managerRoster?: TeamRoster;
+    journeyPath: JourneyPath;
+    playersByCode: Record<number, EnhancedPlayerData>;
+    teamsByCode: Record<FplTeam['code'], FplTeam>;
+    playerSelection: PlayerSelectionState;
+    transferType: TransferType;
+    ownedPlayersByCode: OwnedPlayersByCode;
+    validationContext: Omit<TransferRuleContext, 'transfer'>;
+    onPlayerOutChange: (playerOut: RosterPlayer | null) => void;
+    onPlayerInChange: (playerIn: EnhancedPlayerData | null) => void;
+}
+
+function FirstSelector({
+    availablePlayers,
+    selectedManager,
+    managerRoster,
+    journeyPath,
+    playersByCode,
+    teamsByCode,
+    playerSelection,
+    transferType,
+    ownedPlayersByCode,
+    validationContext,
+    onPlayerOutChange,
+    onPlayerInChange,
+}: SelectorStepProps) {
+    if (!managerRoster) {
+        return null;
+    }
+
+    if (journeyPath === JOURNEY_PATHS.teamFirst) {
+        return (
+            <PlayerOutSelector
+                playersByCode={playersByCode}
+                teamsByCode={teamsByCode}
+                roster={managerRoster}
+                selectedPlayer={playerSelection.playerOut}
+                onPlayerChange={onPlayerOutChange}
+                transferType={transferType}
+            />
+        );
+    }
+
+    return (
+        <PlayerInSelector
+            availablePlayers={availablePlayers}
+            selectedPlayer={playerSelection.playerIn}
+            onPlayerChange={onPlayerInChange}
+            transferType={transferType}
+            playerOut={playerSelection.playerOut}
+            ownedPlayersByCode={ownedPlayersByCode}
+            teamsByCode={teamsByCode}
+            managerId={selectedManager}
+            validationContext={validationContext}
+        />
+    );
+}
+
+function SecondSelector({
+    availablePlayers,
+    selectedManager,
+    managerRoster,
+    journeyPath,
+    playersByCode,
+    teamsByCode,
+    playerSelection,
+    transferType,
+    ownedPlayersByCode,
+    validationContext,
+    onPlayerOutChange,
+    onPlayerInChange,
+}: SelectorStepProps) {
+    if (!managerRoster) {
+        return null;
+    }
+
+    if (journeyPath === JOURNEY_PATHS.teamFirst) {
+        return (
+            <PlayerInSelector
+                availablePlayers={availablePlayers}
+                selectedPlayer={playerSelection.playerIn}
+                onPlayerChange={onPlayerInChange}
+                transferType={transferType}
+                playerOut={playerSelection.playerOut}
+                ownedPlayersByCode={ownedPlayersByCode}
+                teamsByCode={teamsByCode}
+                managerId={selectedManager}
+                validationContext={validationContext}
+            />
+        );
+    }
+
+    return (
+        <PlayerOutSelector
+            playersByCode={playersByCode}
+            teamsByCode={teamsByCode}
+            roster={managerRoster}
+            selectedPlayer={playerSelection.playerOut}
+            onPlayerChange={onPlayerOutChange}
+            transferType={transferType}
+        />
+    );
+}
+
+interface SelectorReviewProps {
+    transferType: TransferType;
+    playerSelection: PlayerSelectionState;
+    playersByCode: Record<number, EnhancedPlayerData>;
+    teamsByCode: Record<FplTeam['code'], FplTeam>;
+    comment: string;
+    onCommentChange: (comment: string) => void;
+    isLoanTransfer: boolean;
+    currentManager?: UserTeamsSheetData;
+    loanSelection: LoanSelectionState;
+    divisionsManagers: UserTeamsSheetData[];
+    selectedManager: ManagerId;
+    onBorrowingManagerChange: (managerId: ManagerId) => void;
+    isBeforeDeadline: boolean;
+    canSubmit: boolean;
+    isSubmitting: boolean;
+}
+
+function SelectorReview({
+    transferType,
+    playerSelection,
+    playersByCode,
+    teamsByCode,
+    comment,
+    onCommentChange,
+    isLoanTransfer,
+    currentManager,
+    loanSelection,
+    divisionsManagers,
+    selectedManager,
+    onBorrowingManagerChange,
+    isBeforeDeadline,
+    canSubmit,
+    isSubmitting,
+}: SelectorReviewProps) {
+    const playerOutFpl = playerSelection.playerOut ? playersByCode[playerSelection.playerOut.playerCode] : null;
+    const playerIn = playerSelection.playerIn;
+    const playerInEligibility = (playerIn as (EnhancedPlayerData & { eligibility?: PlayerEligibility }) | null)
+        ?.eligibility;
+
+    return (
+        <>
+            <div className={styles.reviewSummary}>
+                <div className={styles.reviewRow}>
+                    <span className={styles.reviewLabel}>Type</span>
+                    <span className={styles.reviewValue}>{transferType}</span>
+                </div>
+                {playerOutFpl && playerSelection.playerOut ? (
+                    <div className={styles.reviewRow}>
+                        <span className={styles.reviewLabel}>Player out</span>
+                        <PlayerSummary
+                            player={{ ...playerOutFpl, ...playerSelection.playerOut }}
+                            teamsByCode={teamsByCode}
+                        />
+                    </div>
+                ) : null}
+                {playerIn ? (
+                    <div className={styles.reviewRow}>
+                        <span className={styles.reviewLabel}>Player in</span>
+                        <PlayerSummary
+                            player={playerIn as EnhancedPlayerData & RosterPlayer}
+                            teamsByCode={teamsByCode}
+                        />
+                    </div>
+                ) : null}
+            </div>
+
+            <div className={styles.section}>
+                <label className={styles.label} htmlFor="comment">
+                    Comment
+                </label>
+                <textarea
+                    id="comment"
+                    value={comment}
+                    onChange={(e) => onCommentChange(e.target.value)}
+                    className={styles.textarea}
+                    placeholder="Optional comment about this transfer..."
+                    rows={3}
+                />
+            </div>
+
+            {isLoanTransfer ? (
+                <LoanInfoPanel
+                    transferType={transferType}
+                    currentManager={currentManager}
+                    loanSelection={loanSelection}
+                    managers={divisionsManagers}
+                    managerSelector={
+                        <SelectUser
+                            selectedUser={loanSelection.loanToManager}
+                            users={divisionsManagers.filter((m) => m.userId !== selectedManager)}
+                            handleUserChange={onBorrowingManagerChange}
+                        />
+                    }
+                />
+            ) : null}
+
+            {(playerInEligibility && !playerInEligibility.isEligible) || !isBeforeDeadline ? (
+                <div className={styles.validationErrors}>
+                    {isBeforeDeadline ? null : <div className={styles.blockingIssue}>🚫 Missed the Deadline</div>}
+                    {playerInEligibility && !playerInEligibility.isEligible ? (
+                        <div className={styles.blockingIssue}>🚫 {playerInEligibility.reason}</div>
+                    ) : null}
+                </div>
+            ) : null}
+
+            <div className={styles.section}>
+                <button
+                    type="submit"
+                    disabled={canSubmit}
+                    className={`${styles.submitButton} ${isSubmitting ? styles.loading : ''}`}
+                >
+                    {isSubmitting ? 'Submitting...' : 'Submit Transfer'}
+                </button>
+            </div>
+        </>
+    );
 }
 
 export function TransferForm({
@@ -121,63 +398,32 @@ export function TransferForm({
     const fetcher = useFetcher();
     const { showToast } = useToast();
 
-    const [step, setStep] = useState<JourneyStep>('first-selector');
+    const [step, setStep] = useState<JourneyStep>(JOURNEY_STEPS.firstSelector);
     const [transferType, setTransferType] = useState<TransferType>('TRANSFER');
     const [playerSelection, setPlayerSelection] = useState<PlayerSelectionState>(INITIAL_PLAYER_SELECTION);
     const [loanSelection, setLoanSelection] = useState<LoanSelectionState>(INITIAL_LOAN_SELECTION);
     const [comment, setComment] = useState('');
     const [validation, setValidation] = useState<TransferValidationResult>(INITIAL_VALIDATION);
 
-    const playersByCode: Record<number, EnhancedPlayerData> = availablePlayers.reduce(
-        (acc, player) => ({ ...acc, [player.code]: player }),
-        {},
+    const playersByCode: Record<number, EnhancedPlayerData> = Object.fromEntries(
+        availablePlayers.map((player) => [player.code, player]),
     );
     const divisionsManagers = managers.filter((m) => m.divisionId === selectedDivision);
     const currentManager = divisionsManagers.find((m) => m.userId === selectedManager);
     const ownedPlayersByCode = Object.entries(divisionRosters).reduce((acc: OwnedPlayersByCode, [managerId, team]) => {
         (Object.keys(team.roster) as PositionSlotKey[]).forEach((slotKey) => {
             const slot = team.roster[slotKey];
+            if (!slot) {
+                return;
+            }
             acc[slot.player.playerCode] = { managerId, slotKey, slot };
         });
 
         return acc;
     }, {});
 
-    const getLoanSelectionForTransfer = (
-        nextTransferType: TransferType,
-        nextPlayerSelection: PlayerSelectionState,
-    ): LoanSelectionState => {
-        if (nextTransferType !== 'LOAN_START') {
-            return INITIAL_LOAN_SELECTION;
-        }
-
-        const playerIn = nextPlayerSelection.playerIn;
-        if (!playerIn) {
-            return INITIAL_LOAN_SELECTION;
-        }
-
-        const ownership = getPlayerOwnership(playerIn, ownedPlayersByCode);
-        if (ownership.ownerId && ownership.ownerId !== selectedManager) {
-            return {
-                loanPlayer: playerIn,
-                loanToManager: null,
-                loanFromManager: ownership.ownerId,
-            };
-        }
-
-        if (!ownership.ownerId && nextPlayerSelection.playerOut) {
-            return {
-                loanPlayer: nextPlayerSelection.playerOut,
-                loanToManager: null,
-                loanFromManager: null,
-            };
-        }
-
-        return INITIAL_LOAN_SELECTION;
-    };
-
     const clearForm = () => {
-        setStep('first-selector');
+        setStep(JOURNEY_STEPS.firstSelector);
         setTransferType('TRANSFER');
         setPlayerSelection(INITIAL_PLAYER_SELECTION);
         setLoanSelection(INITIAL_LOAN_SELECTION);
@@ -222,7 +468,9 @@ export function TransferForm({
         };
 
         setPlayerSelection(nextPlayerSelection);
-        setLoanSelection(getLoanSelectionForTransfer(transferType, nextPlayerSelection));
+        setLoanSelection(
+            getLoanSelectionForTransfer(transferType, nextPlayerSelection, ownedPlayersByCode, selectedManager),
+        );
     };
 
     const handlePlayerInChange = (playerIn: EnhancedPlayerData | null) => {
@@ -232,12 +480,16 @@ export function TransferForm({
         };
 
         setPlayerSelection(nextPlayerSelection);
-        setLoanSelection(getLoanSelectionForTransfer(transferType, nextPlayerSelection));
+        setLoanSelection(
+            getLoanSelectionForTransfer(transferType, nextPlayerSelection, ownedPlayersByCode, selectedManager),
+        );
     };
 
     const handleTransferTypeChange = (nextTransferType: TransferType) => {
         setTransferType(nextTransferType);
-        setLoanSelection(getLoanSelectionForTransfer(nextTransferType, playerSelection));
+        setLoanSelection(
+            getLoanSelectionForTransfer(nextTransferType, playerSelection, ownedPlayersByCode, selectedManager),
+        );
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -273,192 +525,101 @@ export function TransferForm({
     };
 
     const goBack = () => {
-        if (step === 'first-selector') {
+        if (step === JOURNEY_STEPS.firstSelector) {
             onExit();
             return;
         }
-        if (step === 'second-selector') {
-            setStep('first-selector');
+        if (step === JOURNEY_STEPS.secondSelector) {
+            setStep(JOURNEY_STEPS.firstSelector);
             return;
         }
-        setStep('second-selector');
+        setStep(JOURNEY_STEPS.secondSelector);
     };
 
     const goForward = () => {
-        if (step === 'first-selector') {
-            setStep('second-selector');
+        if (step === JOURNEY_STEPS.firstSelector) {
+            setStep(JOURNEY_STEPS.secondSelector);
             return;
         }
-        if (step === 'second-selector') {
-            setStep('review');
+        if (step === JOURNEY_STEPS.secondSelector) {
+            setStep(JOURNEY_STEPS.review);
         }
     };
 
     const isLoanTransfer = transferType === 'LOAN_START' || transferType === 'LOAN_END';
     const canSubmit = fetcher.state === 'submitting' || !playerSelection.playerOut || !playerSelection.playerIn;
-    const showContinue = step !== 'review' && canContinue(step, journeyPath, playerSelection);
-    const showTransferTypeSelector = step === 'first-selector' && canContinue(step, journeyPath, playerSelection);
-
-    const renderFirstSelector = () => {
-        if (!selectedManager || !managerRoster) {
-            return null;
-        }
-
-        if (journeyPath === 'team-first') {
-            return (
-                <PlayerOutSelector
-                    playersByCode={playersByCode}
-                    teamsByCode={teamsByCode}
-                    roster={managerRoster}
-                    selectedPlayer={playerSelection.playerOut}
-                    onPlayerChange={handlePlayerOutChange}
-                    transferType={transferType}
-                />
-            );
-        }
-
-        return (
-            <PlayerInSelector
-                availablePlayers={availablePlayers}
-                selectedPlayer={playerSelection.playerIn}
-                onPlayerChange={handlePlayerInChange}
-                transferType={transferType}
-                playerOut={playerSelection.playerOut}
-                ownedPlayersByCode={ownedPlayersByCode}
-                teamsByCode={teamsByCode}
-                managerId={selectedManager}
-                validationContext={validationContext}
-            />
-        );
-    };
-
-    const renderSecondSelector = () => {
-        if (!selectedManager || !managerRoster) {
-            return null;
-        }
-
-        if (journeyPath === 'team-first') {
-            return (
-                <PlayerInSelector
-                    availablePlayers={availablePlayers}
-                    selectedPlayer={playerSelection.playerIn}
-                    onPlayerChange={handlePlayerInChange}
-                    transferType={transferType}
-                    playerOut={playerSelection.playerOut}
-                    ownedPlayersByCode={ownedPlayersByCode}
-                    teamsByCode={teamsByCode}
-                    managerId={selectedManager}
-                    validationContext={validationContext}
-                />
-            );
-        }
-
-        return (
-            <PlayerOutSelector
-                playersByCode={playersByCode}
-                teamsByCode={teamsByCode}
-                roster={managerRoster}
-                selectedPlayer={playerSelection.playerOut}
-                onPlayerChange={handlePlayerOutChange}
-                transferType={transferType}
-            />
-        );
-    };
-
-    const renderReview = () => {
-        const playerOutFpl = playerSelection.playerOut ? playersByCode[playerSelection.playerOut.playerCode] : null;
-        const playerIn = playerSelection.playerIn;
-
-        return (
-            <>
-                <div className={styles.reviewSummary}>
-                    <div className={styles.reviewRow}>
-                        <span className={styles.reviewLabel}>Type</span>
-                        <span className={styles.reviewValue}>{transferType}</span>
-                    </div>
-                    {playerOutFpl && playerSelection.playerOut ? (
-                        <div className={styles.reviewRow}>
-                            <span className={styles.reviewLabel}>Player out</span>
-                            <PlayerSummary
-                                player={{ ...playerOutFpl, ...playerSelection.playerOut }}
-                                teamsByCode={teamsByCode}
-                            />
-                        </div>
-                    ) : null}
-                    {playerIn ? (
-                        <div className={styles.reviewRow}>
-                            <span className={styles.reviewLabel}>Player in</span>
-                            <PlayerSummary player={playerIn} teamsByCode={teamsByCode} />
-                        </div>
-                    ) : null}
-                </div>
-
-                <div className={styles.section}>
-                    <label className={styles.label} htmlFor="comment">
-                        Comment
-                    </label>
-                    <textarea
-                        id="comment"
-                        value={comment}
-                        onChange={(e) => setComment(e.target.value)}
-                        className={styles.textarea}
-                        placeholder="Optional comment about this transfer..."
-                        rows={3}
-                    />
-                </div>
-
-                {isLoanTransfer ? (
-                    <LoanInfoPanel
-                        transferType={transferType}
-                        currentManager={currentManager}
-                        loanSelection={loanSelection}
-                        managers={divisionsManagers}
-                        managerSelector={
-                            <SelectUser
-                                selectedUser={loanSelection.loanToManager}
-                                users={divisionsManagers.filter((m) => m.userId !== selectedManager)}
-                                handleUserChange={handleBorrowingManagerChange}
-                            />
-                        }
-                    />
-                ) : null}
-
-                {(playerIn && !playerIn.eligibility.isEligible) || !isBeforeDeadline ? (
-                    <div className={styles.validationErrors}>
-                        {isBeforeDeadline ? null : <div className={styles.blockingIssue}>🚫 Missed the Deadline</div>}
-                        {playerIn && !playerIn.eligibility.isEligible ? (
-                            <div className={styles.blockingIssue}>🚫 {playerIn.eligibility.reason}</div>
-                        ) : null}
-                    </div>
-                ) : null}
-
-                <div className={styles.section}>
-                    <button
-                        type="submit"
-                        disabled={canSubmit}
-                        className={`${styles.submitButton} ${fetcher.state === 'submitting' ? styles.loading : ''}`}
-                    >
-                        {fetcher.state === 'submitting' ? 'Submitting...' : 'Submit Transfer'}
-                    </button>
-                </div>
-            </>
-        );
-    };
+    const showContinue = step !== JOURNEY_STEPS.review && canContinue(step, journeyPath, playerSelection);
+    const showTransferTypeSelector =
+        step === JOURNEY_STEPS.firstSelector && canContinue(step, journeyPath, playerSelection);
 
     return (
         <div className={styles.journey}>
             <ToastManager maxToasts={3} />
             <div className={styles.journeyHeader}>
                 <button type="button" className={styles.backButton} onClick={goBack}>
-                    ← {step === 'first-selector' ? 'Back to hub' : 'Back'}
+                    ← {step === JOURNEY_STEPS.firstSelector ? 'Back to hub' : 'Back'}
                 </button>
                 <h2 className={styles.journeyTitle}>{STEP_TITLES[step][journeyPath]}</h2>
             </div>
 
             <form onSubmit={handleSubmit} className={styles.form}>
-                {step === 'first-selector' ? <div className={styles.stepContent}>{renderFirstSelector()}</div> : null}
-                {step === 'second-selector' ? <div className={styles.stepContent}>{renderSecondSelector()}</div> : null}
-                {step === 'review' ? <div className={styles.stepContent}>{renderReview()}</div> : null}
+                {step === JOURNEY_STEPS.firstSelector ? (
+                    <div className={styles.stepContent}>
+                        <FirstSelector
+                            availablePlayers={availablePlayers}
+                            selectedManager={selectedManager}
+                            managerRoster={managerRoster}
+                            journeyPath={journeyPath}
+                            playersByCode={playersByCode}
+                            teamsByCode={teamsByCode}
+                            playerSelection={playerSelection}
+                            transferType={transferType}
+                            ownedPlayersByCode={ownedPlayersByCode}
+                            validationContext={validationContext}
+                            onPlayerOutChange={handlePlayerOutChange}
+                            onPlayerInChange={handlePlayerInChange}
+                        />
+                    </div>
+                ) : null}
+                {step === JOURNEY_STEPS.secondSelector ? (
+                    <div className={styles.stepContent}>
+                        <SecondSelector
+                            availablePlayers={availablePlayers}
+                            selectedManager={selectedManager}
+                            managerRoster={managerRoster}
+                            journeyPath={journeyPath}
+                            playersByCode={playersByCode}
+                            teamsByCode={teamsByCode}
+                            playerSelection={playerSelection}
+                            transferType={transferType}
+                            ownedPlayersByCode={ownedPlayersByCode}
+                            validationContext={validationContext}
+                            onPlayerOutChange={handlePlayerOutChange}
+                            onPlayerInChange={handlePlayerInChange}
+                        />
+                    </div>
+                ) : null}
+                {step === JOURNEY_STEPS.review ? (
+                    <div className={styles.stepContent}>
+                        <SelectorReview
+                            transferType={transferType}
+                            playerSelection={playerSelection}
+                            playersByCode={playersByCode}
+                            teamsByCode={teamsByCode}
+                            comment={comment}
+                            onCommentChange={setComment}
+                            isLoanTransfer={isLoanTransfer}
+                            currentManager={currentManager}
+                            loanSelection={loanSelection}
+                            divisionsManagers={divisionsManagers}
+                            selectedManager={selectedManager}
+                            onBorrowingManagerChange={handleBorrowingManagerChange}
+                            isBeforeDeadline={isBeforeDeadline}
+                            canSubmit={canSubmit}
+                            isSubmitting={fetcher.state === 'submitting'}
+                        />
+                    </div>
+                ) : null}
 
                 {showContinue ? (
                     <div className={styles.journeyFooter}>

--- a/draft/app/transfers/components/transfer-form.tsx
+++ b/draft/app/transfers/components/transfer-form.tsx
@@ -2,11 +2,12 @@
 
 import type * as React from 'react';
 import { useEffect, useState } from 'react';
-import { useFetcher, useSearchParams } from 'react-router';
+import { useFetcher } from 'react-router';
 import { SelectUser } from '../../_shared/components/select-user';
 import { ToastManager, useToast } from '../../_shared/components/toast-manager';
 import { playCelebrationSound } from '../../_shared/lib/audio/celebration-sounds';
 import type { FplTeam, GameWeekData } from '../../_shared/lib/fpl/fpl-types';
+import { PlayerSummary } from '../../players/components/player';
 import type { EnhancedPlayerData } from '../../scoring/types/scoring-types';
 import type {
     DivisionId,
@@ -28,6 +29,10 @@ import { PlayerOutSelector } from './player-out-selector';
 import styles from './transfer-form.module.css';
 import { TransferTypeSelector } from './transfer-type-selector';
 
+export type JourneyPath = 'team-first' | 'player-list-first';
+
+type JourneyStep = 'first-selector' | 'transaction-type' | 'second-selector' | 'review';
+
 interface TransferFormProps {
     divisions: DivisionSheetData[];
     managers: UserTeamsSheetData[];
@@ -42,6 +47,8 @@ interface TransferFormProps {
     divisionRosters: RosterByManagerId;
     teamsByCode: Record<FplTeam['code'], FplTeam>;
     validationContext: Omit<TransferRuleContext, 'transfer'>;
+    journeyPath: JourneyPath;
+    onExit: () => void;
 }
 
 interface LoanSelectionState {
@@ -68,6 +75,42 @@ const INITIAL_VALIDATION: TransferValidationResult = {
     blockingIssues: [],
 };
 
+const STEP_TITLES: Record<JourneyStep, Record<JourneyPath, string>> = {
+    'first-selector': {
+        'team-first': 'Select player from your team',
+        'player-list-first': 'Select player from list',
+    },
+    'transaction-type': {
+        'team-first': 'Choose transaction type',
+        'player-list-first': 'Choose transaction type',
+    },
+    'second-selector': {
+        'team-first': 'Select player to bring in',
+        'player-list-first': 'Select player to remove',
+    },
+    review: {
+        'team-first': 'Review and submit',
+        'player-list-first': 'Review and submit',
+    },
+};
+
+function canContinue(step: JourneyStep, journeyPath: JourneyPath, playerSelection: PlayerSelectionState): boolean {
+    switch (step) {
+        case 'first-selector':
+            return journeyPath === 'team-first'
+                ? playerSelection.playerOut !== null
+                : playerSelection.playerIn !== null;
+        case 'transaction-type':
+            return true;
+        case 'second-selector':
+            return journeyPath === 'team-first'
+                ? playerSelection.playerIn !== null
+                : playerSelection.playerOut !== null;
+        case 'review':
+            return false;
+    }
+}
+
 export function TransferForm({
     managers,
     selectedDivision,
@@ -78,12 +121,14 @@ export function TransferForm({
     divisionRosters,
     teamsByCode,
     validationContext,
+    journeyPath,
+    onExit,
 }: TransferFormProps) {
-    const [searchParams, setSearchParams] = useSearchParams();
     const fetcher = useFetcher();
     const { showToast } = useToast();
-    const TransferType: TransferType = (searchParams.get('transferType') as TransferType) || 'TRANSFER';
 
+    const [step, setStep] = useState<JourneyStep>('first-selector');
+    const [transferType, setTransferType] = useState<TransferType>('TRANSFER');
     const [playerSelection, setPlayerSelection] = useState<PlayerSelectionState>(INITIAL_PLAYER_SELECTION);
     const [loanSelection, setLoanSelection] = useState<LoanSelectionState>(INITIAL_LOAN_SELECTION);
     const [comment, setComment] = useState('');
@@ -104,22 +149,22 @@ export function TransferForm({
         return acc;
     }, {});
 
-    // Clear form after successful submission
     const clearForm = () => {
+        setStep('first-selector');
+        setTransferType('TRANSFER');
         setPlayerSelection(INITIAL_PLAYER_SELECTION);
         setLoanSelection(INITIAL_LOAN_SELECTION);
         setComment('');
         setValidation(INITIAL_VALIDATION);
     };
 
-    // Handle form submission response
     useEffect(() => {
         if (fetcher.state === 'idle' && fetcher.data) {
             const result = fetcher.data;
 
             if (result.success) {
-                // Success: Clear form, show toast with sound
                 clearForm();
+                onExit();
                 playCelebrationSound();
                 showToast({
                     type: 'success',
@@ -127,7 +172,6 @@ export function TransferForm({
                     duration: 5000,
                 });
             } else if (result.error) {
-                // Error: Show error toast
                 showToast({
                     type: 'error',
                     message: result.error,
@@ -135,17 +179,7 @@ export function TransferForm({
                 });
             }
         }
-    }, [fetcher.state, fetcher.data, showToast]);
-
-    // const handleManagerChange = (managerId: ManagerId) => {
-    //     const newParams = new URLSearchParams(searchParams);
-    //     newParams.set('manager', managerId);
-    //     setSearchParams(newParams);
-    //
-    //     // Reset player selection when manager changes
-    //     setPlayerSelection(INITIAL_PLAYER_SELECTION);
-    //     setLoanSelection(INITIAL_LOAN_SELECTION);
-    // };
+    }, [fetcher.state, fetcher.data, showToast, onExit]);
 
     const handleBorrowingManagerChange = (managerId: ManagerId) => {
         setLoanSelection((curr) => ({
@@ -167,32 +201,28 @@ export function TransferForm({
             playerIn,
         }));
 
-        // Auto-determine loan relationships for owned players
-        if (playerIn && TransferType === 'LOAN_START') {
+        if (playerIn && transferType === 'LOAN_START') {
             const ownership = getPlayerOwnership(playerIn, ownedPlayersByCode);
             if (ownership.ownerId && ownership.ownerId !== selectedManager) {
                 setLoanSelection({
                     loanPlayer: playerIn,
-                    loanToManager: null, // loan to is to be only used for playerOut
+                    loanToManager: null,
                     loanFromManager: ownership.ownerId,
                 });
             } else if (!ownership.ownerId) {
                 setLoanSelection({
                     loanPlayer: playerSelection.playerOut,
-                    loanToManager: null, // loan to is to be only used for playerOut
+                    loanToManager: null,
                     loanFromManager: null,
                 });
             }
         }
     };
 
-    const handleTransferTypeChange = (transferType: TransferType) => {
-        const newParams = new URLSearchParams(searchParams);
-        newParams.set('transferType', transferType);
-        setSearchParams(newParams);
+    const handleTransferTypeChange = (nextTransferType: TransferType) => {
+        setTransferType(nextTransferType);
 
-        // Reset loan selection when changing transfer type
-        if (transferType !== 'LOAN_START' && transferType !== 'LOAN_END') {
+        if (nextTransferType !== 'LOAN_START' && nextTransferType !== 'LOAN_END') {
             setLoanSelection(INITIAL_LOAN_SELECTION);
         }
     };
@@ -208,18 +238,16 @@ export function TransferForm({
         formData.append('actionType', 'submitTransfer');
         formData.append('divisionId', selectedDivision);
         formData.append('managerId', selectedManager);
-        formData.append('transferType', TransferType || 'Transfer');
+        formData.append('transferType', transferType || 'Transfer');
         formData.append('playerOutCode', playerSelection.playerOut?.playerCode.toString() || '');
         formData.append('playerInCode', playerSelection.playerIn?.code.toString() || '');
         formData.append('comment', comment);
 
-        // Add loan fields for loan transfers
-        if (TransferType === 'LOAN_START') {
+        if (transferType === 'LOAN_START') {
             formData.append('onLoanTo', loanSelection.loanToManager || '');
             formData.append('onLoanFrom', loanSelection.loanFromManager || '');
         }
 
-        // Optimistic update: immediately add to transfer list
         if (playerSelection.playerOut && playerSelection.playerIn) {
             showToast({
                 type: 'info',
@@ -231,58 +259,140 @@ export function TransferForm({
         fetcher.submit(formData, { method: 'post' });
     };
 
-    // Determine if this is a loan transfer type
-    const isLoanTransfer = TransferType === 'LOAN_START' || TransferType === 'LOAN_END';
-    const canSubmit =
-        // playerSelection.playerIn?.eligibility.isEligible ||
-        // !isBeforeDeadline ||
-        fetcher.state === 'submitting' || !playerSelection.playerOut || !playerSelection.playerIn;
+    const goBack = () => {
+        if (step === 'first-selector') {
+            onExit();
+            return;
+        }
+        if (step === 'transaction-type') {
+            setStep('first-selector');
+            return;
+        }
+        if (step === 'second-selector') {
+            setStep('transaction-type');
+            return;
+        }
+        setStep('second-selector');
+    };
 
-    return (
-        <div>
-            <ToastManager maxToasts={3} />
-            <form onSubmit={handleSubmit} className={styles.form}>
-                <div className={styles.section}>
-                    <TransferTypeSelector selectedType={TransferType} onTypeChange={handleTransferTypeChange} />
+    const goForward = () => {
+        if (step === 'first-selector') {
+            setStep('transaction-type');
+            return;
+        }
+        if (step === 'transaction-type') {
+            setStep('second-selector');
+            return;
+        }
+        if (step === 'second-selector') {
+            setStep('review');
+        }
+    };
+
+    const isLoanTransfer = transferType === 'LOAN_START' || transferType === 'LOAN_END';
+    const canSubmit = fetcher.state === 'submitting' || !playerSelection.playerOut || !playerSelection.playerIn;
+    const showContinue = step !== 'review' && canContinue(step, journeyPath, playerSelection);
+
+    const renderFirstSelector = () => {
+        if (!selectedManager || !managerRoster) {
+            return null;
+        }
+
+        if (journeyPath === 'team-first') {
+            return (
+                <PlayerOutSelector
+                    playersByCode={playersByCode}
+                    teamsByCode={teamsByCode}
+                    roster={managerRoster}
+                    selectedPlayer={playerSelection.playerOut}
+                    onPlayerChange={handlePlayerOutChange}
+                    transferType={transferType}
+                />
+            );
+        }
+
+        return (
+            <PlayerInSelector
+                availablePlayers={availablePlayers}
+                selectedPlayer={playerSelection.playerIn}
+                onPlayerChange={handlePlayerInChange}
+                transferType={transferType}
+                playerOut={playerSelection.playerOut}
+                ownedPlayersByCode={ownedPlayersByCode}
+                teamsByCode={teamsByCode}
+                managerId={selectedManager}
+                validationContext={validationContext}
+            />
+        );
+    };
+
+    const renderSecondSelector = () => {
+        if (!selectedManager || !managerRoster) {
+            return null;
+        }
+
+        if (journeyPath === 'team-first') {
+            return (
+                <PlayerInSelector
+                    availablePlayers={availablePlayers}
+                    selectedPlayer={playerSelection.playerIn}
+                    onPlayerChange={handlePlayerInChange}
+                    transferType={transferType}
+                    playerOut={playerSelection.playerOut}
+                    ownedPlayersByCode={ownedPlayersByCode}
+                    teamsByCode={teamsByCode}
+                    managerId={selectedManager}
+                    validationContext={validationContext}
+                />
+            );
+        }
+
+        return (
+            <PlayerOutSelector
+                playersByCode={playersByCode}
+                teamsByCode={teamsByCode}
+                roster={managerRoster}
+                selectedPlayer={playerSelection.playerOut}
+                onPlayerChange={handlePlayerOutChange}
+                transferType={transferType}
+            />
+        );
+    };
+
+    const renderReview = () => {
+        const playerOutFpl = playerSelection.playerOut ? playersByCode[playerSelection.playerOut.playerCode] : null;
+        const playerIn = playerSelection.playerIn;
+
+        return (
+            <>
+                <div className={styles.reviewSummary}>
+                    <div className={styles.reviewRow}>
+                        <span className={styles.reviewLabel}>Type</span>
+                        <span className={styles.reviewValue}>{transferType}</span>
+                    </div>
+                    {playerOutFpl && playerSelection.playerOut ? (
+                        <div className={styles.reviewRow}>
+                            <span className={styles.reviewLabel}>Player out</span>
+                            <PlayerSummary
+                                player={{ ...playerOutFpl, ...playerSelection.playerOut }}
+                                teamsByCode={teamsByCode}
+                            />
+                        </div>
+                    ) : null}
+                    {playerIn ? (
+                        <div className={styles.reviewRow}>
+                            <span className={styles.reviewLabel}>Player in</span>
+                            <PlayerSummary player={playerIn} teamsByCode={teamsByCode} />
+                        </div>
+                    ) : null}
                 </div>
 
-                {/* Player Selection */}
-                {selectedManager && managerRoster && (
-                    <>
-                        <div className={styles.section}>
-                            <PlayerOutSelector
-                                playersByCode={playersByCode}
-                                teamsByCode={teamsByCode}
-                                roster={managerRoster}
-                                selectedPlayer={playerSelection.playerOut}
-                                onPlayerChange={handlePlayerOutChange}
-                                transferType={TransferType}
-                            />
-                        </div>
-                        <hr />
-                        <div className={styles.section}>
-                            <PlayerInSelector
-                                availablePlayers={availablePlayers}
-                                selectedPlayer={playerSelection.playerIn}
-                                onPlayerChange={handlePlayerInChange}
-                                transferType={TransferType}
-                                playerOut={playerSelection.playerOut}
-                                ownedPlayersByCode={ownedPlayersByCode}
-                                teamsByCode={teamsByCode}
-                                managerId={selectedManager}
-                                validationContext={validationContext}
-                            />
-                        </div>
-                    </>
-                )}
-
-                {/* Comment */}
                 <div className={styles.section}>
-                    <label className={styles.label} htmlFor={'comment'}>
+                    <label className={styles.label} htmlFor="comment">
                         Comment
                     </label>
                     <textarea
-                        id={'comment'}
+                        id="comment"
                         value={comment}
                         onChange={(e) => setComment(e.target.value)}
                         className={styles.textarea}
@@ -291,10 +401,9 @@ export function TransferForm({
                     />
                 </div>
 
-                {/* Loan Information Panel */}
-                {isLoanTransfer && (
+                {isLoanTransfer ? (
                     <LoanInfoPanel
-                        transferType={TransferType}
+                        transferType={transferType}
                         currentManager={currentManager}
                         loanSelection={loanSelection}
                         managers={divisionsManagers}
@@ -306,22 +415,17 @@ export function TransferForm({
                             />
                         }
                     />
-                )}
+                ) : null}
 
-                {/* Validation Messages */}
-                {((playerSelection.playerIn && !playerSelection.playerIn?.eligibility.isEligible) ||
-                    !isBeforeDeadline) && (
+                {(playerIn && !playerIn.eligibility.isEligible) || !isBeforeDeadline ? (
                     <div className={styles.validationErrors}>
-                        {!isBeforeDeadline && <div className={styles.blockingIssue}>🚫 Missed the Deadline</div>}
-                        {!playerSelection.playerIn?.eligibility.isEligible && (
-                            <div className={styles.blockingIssue}>
-                                🚫 {playerSelection.playerIn?.eligibility.reason}
-                            </div>
-                        )}
+                        {isBeforeDeadline ? null : <div className={styles.blockingIssue}>🚫 Missed the Deadline</div>}
+                        {playerIn && !playerIn.eligibility.isEligible ? (
+                            <div className={styles.blockingIssue}>🚫 {playerIn.eligibility.reason}</div>
+                        ) : null}
                     </div>
-                )}
+                ) : null}
 
-                {/* Submit Button */}
                 <div className={styles.section}>
                     <button
                         type="submit"
@@ -331,6 +435,37 @@ export function TransferForm({
                         {fetcher.state === 'submitting' ? 'Submitting...' : 'Submit Transfer'}
                     </button>
                 </div>
+            </>
+        );
+    };
+
+    return (
+        <div className={styles.journey}>
+            <ToastManager maxToasts={3} />
+            <div className={styles.journeyHeader}>
+                <button type="button" className={styles.backButton} onClick={goBack}>
+                    ← {step === 'first-selector' ? 'Back to hub' : 'Back'}
+                </button>
+                <h2 className={styles.journeyTitle}>{STEP_TITLES[step][journeyPath]}</h2>
+            </div>
+
+            <form onSubmit={handleSubmit} className={styles.form}>
+                {step === 'first-selector' ? <div className={styles.stepContent}>{renderFirstSelector()}</div> : null}
+                {step === 'transaction-type' ? (
+                    <div className={styles.stepContent}>
+                        <TransferTypeSelector selectedType={transferType} onTypeChange={handleTransferTypeChange} />
+                    </div>
+                ) : null}
+                {step === 'second-selector' ? <div className={styles.stepContent}>{renderSecondSelector()}</div> : null}
+                {step === 'review' ? <div className={styles.stepContent}>{renderReview()}</div> : null}
+
+                {showContinue ? (
+                    <div className={styles.journeyFooter}>
+                        <button type="button" className={styles.continueButton} onClick={goForward}>
+                            Continue
+                        </button>
+                    </div>
+                ) : null}
             </form>
         </div>
     );

--- a/draft/app/transfers/transfers.page.module.css
+++ b/draft/app/transfers/transfers.page.module.css
@@ -5,32 +5,21 @@
     margin: 0 auto;
 }
 
-.formSection {
-    background: var(--color-white);
-    border: 1px solid var(--color-gray-200);
-    border-radius: var(--radius-lg);
-    padding: var(--spacing-6);
-    box-shadow: var(--shadow-sm);
+.hub {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-4);
 }
 
-.sectionHeader {
-    margin-bottom: var(--spacing-6);
-    padding-bottom: var(--spacing-4);
-    border-bottom: 1px solid var(--color-gray-200);
-}
-
-.sectionTitle {
-    font-size: var(--font-xl);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-gray-900);
-    margin-bottom: var(--spacing-2);
+.hubSection {
+    width: 100%;
 }
 
 .deadlineInfo {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: var(--spacing-3);
-    margin-top: var(--spacing-3);
     padding: var(--spacing-3);
     background: var(--color-gray-50);
     border-radius: var(--radius-md);
@@ -63,4 +52,67 @@
     padding: var(--spacing-1) var(--spacing-2);
     border-radius: var(--radius-sm);
     font-size: var(--font-xs);
+}
+
+.entryPoints {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+}
+
+.entryButton {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-1);
+    width: 100%;
+    padding: var(--spacing-4);
+    background: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    text-align: left;
+    transition:
+        border-color var(--transition-normal),
+        box-shadow var(--transition-normal);
+    min-height: 56px;
+}
+
+.entryButton:hover:not(:disabled) {
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-sm);
+}
+
+.entryButton:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.entryButtonTitle {
+    font-size: var(--font-base);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.entryButtonDescription {
+    font-size: var(--font-sm);
+    color: var(--color-gray-600);
+}
+
+.card {
+    background: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-4);
+    box-shadow: var(--shadow-sm);
+}
+
+@media (min-width: 640px) {
+    .entryPoints {
+        flex-direction: row;
+    }
+
+    .entryButton {
+        flex: 1;
+    }
 }

--- a/draft/app/transfers/transfers.page.tsx
+++ b/draft/app/transfers/transfers.page.tsx
@@ -1,5 +1,6 @@
 /* Location: app/transfers/transfers.page.tsx */
 
+import { useCallback, useState } from 'react';
 import { useLoaderData, useSearchParams } from 'react-router';
 import { PageHeader } from '../_shared/components/page-header';
 import { SelectUser } from '../_shared/components/select-user';
@@ -9,7 +10,7 @@ import { GameweekSelector } from '../teams/components/gameweek-selector';
 import type { ManagerId, PositionSlotKey, RosterPlayer } from '../teams/types/team-types';
 import { CurrentTransfers } from './components/current-transfers';
 import { LoanStatusDisplay } from './components/loan-status-display';
-import { TransferForm } from './components/transfer-form';
+import { type JourneyPath, TransferForm } from './components/transfer-form';
 import styles from './transfers.page.module.css';
 import type { TransfersPageData } from './types/transfer-form-types';
 
@@ -25,7 +26,7 @@ export const TransfersPage = () => {
         <UserSelectionProvider
             users={data.userTeams}
             onUserSelected={console.log}
-            redirectOnSelection={false} // Reload page with new user
+            redirectOnSelection={false}
             fallbackContent={
                 <div style={{ textAlign: 'center', padding: '2rem' }}>
                     <h2>Welcome to Fantasy Football!</h2>
@@ -41,7 +42,9 @@ export const TransfersPage = () => {
 
 export const TransfersPageComp = (data: TransfersPageData) => {
     const [searchParams, setSearchParams] = useSearchParams();
-    // const navigate = useNavigate();
+    const [activeJourney, setActiveJourney] = useState<JourneyPath | null>(null);
+    const handleExitJourney = useCallback(() => setActiveJourney(null), []);
+
     const isCurrentGameweek =
         !searchParams.get('gameweek') || searchParams.get('gameweek') === String(data.currentGameweek);
 
@@ -62,81 +65,103 @@ export const TransfersPageComp = (data: TransfersPageData) => {
         });
     }
 
+    const divisionLabel = data.divisions.find((d) => d.id === data.selectedDivision)?.label;
+
+    if (activeJourney && data.selectedUser) {
+        return (
+            <div className={styles.pageContainer}>
+                <TransferForm
+                    divisions={data.divisions}
+                    managers={data.managers}
+                    currentGameweek={data.currentGameweek}
+                    availableGameweeks={data.availableGameweeks}
+                    selectedGameweekData={data.selectedGameweekData}
+                    selectedDivision={data.selectedDivision}
+                    selectedManager={data.selectedUser}
+                    managerRoster={data.managerRoster}
+                    availablePlayers={data.availablePlayers}
+                    isBeforeDeadline={data.isBeforeDeadline}
+                    divisionRosters={data.divisionRosters}
+                    teamsByCode={data.teamsByCode}
+                    validationContext={data.validationContext}
+                    journeyPath={activeJourney}
+                    onExit={handleExitJourney}
+                />
+            </div>
+        );
+    }
+
     return (
         <div className={styles.pageContainer}>
-            <PageHeader
-                title={`${data.divisions.find((d) => d.id === data.selectedDivision)?.label} Transfers`}
-                actions={
-                    <>
-                        <SelectUser
-                            selectedUser={data.selectedUser}
-                            users={data.userTeams}
-                            handleUserChange={(userId) => {
-                                const newParams = new URLSearchParams(searchParams);
-                                newParams.set('userId', userId);
-                                setSearchParams(newParams);
-                            }}
-                        />
-                        <GameweekSelector
-                            currentGameweekData={data.currentGameweekData}
-                            selectedGameweekData={data.selectedGameweekData}
-                            availableGameweeks={data.availableGameweeks}
-                        />
-                    </>
-                }
-            />
+            <PageHeader title={`${divisionLabel} Transfers`} />
 
-            {!isCurrentGameweek && <TimeTravelBanner currentGameweek={data.currentGameweek} />}
+            {isCurrentGameweek ? null : <TimeTravelBanner currentGameweek={data.currentGameweek} />}
 
-            {/* Current Transfers Section */}
-            <div className={'card'}>
-                {data.currentTransfers ? (
-                    <CurrentTransfers
-                        teamsByCode={data.teamsByCode}
-                        transfers={data.currentTransfers}
-                        currentGameweek={data.currentGameweek}
-                        availableGameweeks={data.availableGameweeks}
-                        selectedGameweek={data.selectedGameweek}
-                        selectedDivision={data.selectedDivision}
+            <div className={styles.hub}>
+                <div className={styles.hubSection}>
+                    <SelectUser
+                        selectedUser={data.selectedUser}
+                        users={data.userTeams}
+                        handleUserChange={(userId) => {
+                            const newParams = new URLSearchParams(searchParams);
+                            newParams.set('userId', userId);
+                            setSearchParams(newParams);
+                        }}
                     />
-                ) : null}
-            </div>
-            <br />
-            <br />
-            <div>
-                {/* Transfer Form Section */}
-                <div className={styles.formSection}>
-                    <div className={styles.sectionHeader}>
-                        <h2 className={styles.sectionTitle}>Submit New Transfer</h2>
-                        <div className={styles.deadlineInfo}>
-                            <span className={styles.deadlineLabel}>Deadline:</span>
-                            <span className={styles.deadlineValue}>{data.transferDeadline}</span>
-                            {data.isBeforeDeadline ? (
-                                <span className={styles.deadlineStatus}>✓ Open</span>
-                            ) : (
-                                <span className={styles.deadlineStatusClosed}>✗ Closed</span>
-                            )}
-                        </div>
-                    </div>
+                </div>
 
-                    {data.selectedUser ? (
-                        <TransferForm
-                            divisions={data.divisions}
-                            managers={data.managers}
+                <div className={styles.deadlineInfo}>
+                    <span className={styles.deadlineLabel}>Deadline:</span>
+                    <span className={styles.deadlineValue}>{data.transferDeadline}</span>
+                    {data.isBeforeDeadline ? (
+                        <span className={styles.deadlineStatus}>✓ Open</span>
+                    ) : (
+                        <span className={styles.deadlineStatusClosed}>✗ Closed</span>
+                    )}
+                </div>
+
+                <div className={styles.hubSection}>
+                    <GameweekSelector
+                        currentGameweekData={data.currentGameweekData}
+                        selectedGameweekData={data.selectedGameweekData}
+                        availableGameweeks={data.availableGameweeks}
+                    />
+                </div>
+
+                <div className={styles.entryPoints}>
+                    <button
+                        type="button"
+                        className={styles.entryButton}
+                        disabled={!data.selectedUser}
+                        onClick={() => setActiveJourney('team-first')}
+                    >
+                        <span className={styles.entryButtonTitle}>Start with My Team</span>
+                        <span className={styles.entryButtonDescription}>Choose a player from your squad first</span>
+                    </button>
+                    <button
+                        type="button"
+                        className={styles.entryButton}
+                        disabled={!data.selectedUser}
+                        onClick={() => setActiveJourney('player-list-first')}
+                    >
+                        <span className={styles.entryButtonTitle}>Start with Player List</span>
+                        <span className={styles.entryButtonDescription}>Browse available players first</span>
+                    </button>
+                </div>
+
+                <div className={styles.card}>
+                    {data.currentTransfers ? (
+                        <CurrentTransfers
+                            teamsByCode={data.teamsByCode}
+                            transfers={data.currentTransfers}
                             currentGameweek={data.currentGameweek}
                             availableGameweeks={data.availableGameweeks}
-                            selectedGameweekData={data.selectedGameweekData}
+                            selectedGameweek={data.selectedGameweek}
                             selectedDivision={data.selectedDivision}
-                            selectedManager={data.selectedUser}
-                            managerRoster={data.managerRoster}
-                            availablePlayers={data.availablePlayers}
-                            isBeforeDeadline={true /* data.isBeforeDeadline */}
-                            divisionRosters={data.divisionRosters}
-                            teamsByCode={data.teamsByCode}
-                            validationContext={data.validationContext}
                         />
                     ) : null}
                 </div>
+
                 <LoanStatusDisplay
                     teamsByCode={data.teamsByCode}
                     fplPlayersByCode={data.fplPlayersByCode}

--- a/draft/app/transfers/transfers.page.tsx
+++ b/draft/app/transfers/transfers.page.tsx
@@ -1,6 +1,6 @@
 /* Location: app/transfers/transfers.page.tsx */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLoaderData, useSearchParams } from 'react-router';
 import { PageHeader } from '../_shared/components/page-header';
 import { SelectUser } from '../_shared/components/select-user';
@@ -44,6 +44,11 @@ export const TransfersPageComp = (data: TransfersPageData) => {
     const [searchParams, setSearchParams] = useSearchParams();
     const [activeJourney, setActiveJourney] = useState<JourneyPath | null>(null);
     const handleExitJourney = useCallback(() => setActiveJourney(null), []);
+    const gameweekParam = searchParams.get('gameweek') ?? '';
+
+    useEffect(() => {
+        setActiveJourney(null);
+    }, [data.selectedUser, gameweekParam]);
 
     const isCurrentGameweek =
         !searchParams.get('gameweek') || searchParams.get('gameweek') === String(data.currentGameweek);


### PR DESCRIPTION
**Summary**

Restructures /transfers into a mobile-first Transfer Hub with two journey entry points, replacing the always-visible inline form with a step-based flow while keeping existing data, validation, and submission behaviour unchanged.

**Hub:** Select user, deadline status, gameweek selector, journey entry buttons, current transfers list, and loan status — same elements as before, reordered for mobile.

**Journey:** Full-screen steps for team-first (out → in → review) and player-list-first (in → out → review). TransferTypeSelector stays hidden while browsing and only appears after the first player is selected. Comment, loan fields, and submit live on the review step only.

Also fixes isBeforeDeadline being hardcoded to true, and resets journey state when the selected user or gameweek changes.

**Test plan**

-  Hub layout at 414px — all sections present and in order
-  Team-first and player-list-first paths end-to-end
-  Browse-only exit — no transaction type shown without a player selection
-  Loan type change after first selection behaves correctly on both paths
-  User/gameweek change on hub clears any stale journey state
-  Successful submit returns to hub with success toast