### PR TITLE
Add Cup feature (cross-division knockout)

### DIFF
--- a/draft/app/_shared/lib/cache/cache-config.ts
+++ b/draft/app/_shared/lib/cache/cache-config.ts
@@ -26,6 +26,8 @@ const CACHE_TTL = {
     SHEETS_DRAFT: 2 * 60 * 1000, // 2 minutes - draft picks change during drafts (reduced from 5 min)
     SHEETS_TRANSFERS: 30 * 1000, // 30s - can change during drafts
     SHEETS_PLAYERS: 24 * 60 * 60 * 1000, // 24 hours - player positions might be updated
+    SHEETS_CUP: 30 * 1000, // 30s - cup submissions change up to the deadline
+    SHEETS_CUP_CONFIG: 5 * 60 * 1000, // 5 min - stage->gameweek map, changed rarely by admin
 
     // Firebase/Firestore Data - real-time or frequently changing
     FIREBASE_DRAFT_STATE: 150 * 1000, // 150 seconds - changes rapidly during draft
@@ -72,6 +74,9 @@ export const CACHE_KEYS = {
         DRAFT: 'sheets:draft-picks',
         TRANSFERS: (divisionId: string) => `sheets:transfers:${divisionId}`,
         PLAYERS: 'sheets:players',
+        // Cup is cross-division, so a single (non-division-scoped) key.
+        CUP: 'sheets:cup',
+        CUP_CONFIG: 'sheets:cup-config',
     },
 
     // Firebase keys
@@ -108,6 +113,12 @@ export const CACHE_INVALIDATION_RULES = {
 
     // When transfers add submitted by managers
     TRANSFERS_UPDATED: (divisionId: string) => [CACHE_KEYS.SHEETS.TRANSFERS(divisionId)],
+
+    // When a cup team is submitted (by a manager or admin)
+    CUP_SUBMITTED: [CACHE_KEYS.SHEETS.CUP],
+
+    // When an admin changes the stage->gameweek mapping
+    CUP_CONFIG_CHANGED: [CACHE_KEYS.SHEETS.CUP_CONFIG, CACHE_KEYS.SHEETS.CUP],
 
     // When transfers + points are processed
     TRANSFERS_PROCESSED: (divisionId: string, gameWeek: number) => [
@@ -168,6 +179,8 @@ export function getCacheTTL(key: string): number {
     if (key.includes('sheets:user-teams')) return CACHE_TTL.SHEETS_USER_TEAMS;
     if (key.includes('sheets:players')) return CACHE_TTL.SHEETS_PLAYERS;
     if (key.includes('sheets:transfers')) return CACHE_TTL.SHEETS_TRANSFERS;
+    if (key.includes('sheets:cup-config')) return CACHE_TTL.SHEETS_CUP_CONFIG;
+    if (key.includes('sheets:cup')) return CACHE_TTL.SHEETS_CUP;
     if (key.includes('sheets:draft-state')) return CACHE_TTL.SHEETS_DRAFT_STATE;
     if (key.includes('sheets:draft-picks')) return CACHE_TTL.SHEETS_DRAFT;
     if (key.includes('sheets:draft-orders')) return CACHE_TTL.SHEETS_DRAFT_ORDERS;

--- a/draft/app/_shared/lib/cache/cache-config.ts
+++ b/draft/app/_shared/lib/cache/cache-config.ts
@@ -77,6 +77,7 @@ export const CACHE_KEYS = {
         // Cup is cross-division, so a single (non-division-scoped) key.
         CUP: 'sheets:cup',
         CUP_CONFIG: 'sheets:cup-config',
+        CUP_BRACKET: 'sheets:cup-bracket',
     },
 
     // Firebase keys
@@ -180,6 +181,7 @@ export function getCacheTTL(key: string): number {
     if (key.includes('sheets:players')) return CACHE_TTL.SHEETS_PLAYERS;
     if (key.includes('sheets:transfers')) return CACHE_TTL.SHEETS_TRANSFERS;
     if (key.includes('sheets:cup-config')) return CACHE_TTL.SHEETS_CUP_CONFIG;
+    if (key.includes('sheets:cup-bracket')) return CACHE_TTL.SHEETS_CUP_CONFIG;
     if (key.includes('sheets:cup')) return CACHE_TTL.SHEETS_CUP;
     if (key.includes('sheets:draft-state')) return CACHE_TTL.SHEETS_DRAFT_STATE;
     if (key.includes('sheets:draft-picks')) return CACHE_TTL.SHEETS_DRAFT;

--- a/draft/app/_shared/lib/sheets/cup.ts
+++ b/draft/app/_shared/lib/sheets/cup.ts
@@ -1,0 +1,199 @@
+/* Location: app/_shared/lib/sheets/cup.ts */
+
+import { parseCupConfig, serializeCupConfig } from '../../../cup/lib/cup-config';
+import type { CupConfig, CupSheetData, CupStageId, ProcessedCupSheetData } from '../../../cup/types/cup-types';
+import type { DivisionId } from '../../../teams/types/team-types';
+import { CACHE_KEYS, getCacheTTL } from '../cache/cache-config';
+import { dataCache } from '../cache/data-cache.service';
+import { convertToRowsWithHeaders, getCachedHeaders, setCachedHeaders } from './cache/utils';
+import { appendToSheet, createAppError, readSheetRange, type SheetRange } from './utils/common';
+import { readDataFromSheet } from './utils/read-data-from-sheets';
+
+// The cup is cross-division, so submissions live in a single tab (not per-division).
+const CUP_SHEET_NAME = 'Cup';
+const CUP_CONFIG_SHEET_NAME = 'CupConfig';
+
+const CUP_HEADERS: Record<keyof CupSheetData, keyof ProcessedCupSheetData> = {
+    Status: 'status',
+    Timestamp: 'timestamp',
+    Manager: 'manager',
+    Division: 'division',
+    Gameweek: 'gameweek',
+    Stage: 'stage',
+    Leg: 'leg',
+    Players: 'players',
+    SubmittedByAdmin: 'submittedByAdmin',
+    AdminReason: 'adminReason',
+};
+
+const CUP_SHEET_HEADERS = [
+    'Status',
+    'Timestamp',
+    'Manager',
+    'Division',
+    'Gameweek',
+    'Stage',
+    'Leg',
+    'Players',
+    'SubmittedByAdmin',
+    'AdminReason',
+] as const;
+
+const CUP_TRANSFORM_FUNCTIONS = {
+    Status: (value: any): string => {
+        if (!value || value === '') return '';
+        return String(value).trim().toUpperCase();
+    },
+    Timestamp: (value: any): Date => {
+        if (!value) throw new Error('Timestamp is required');
+        if (value instanceof Date) return value;
+        if (typeof value === 'string') {
+            const parsed = new Date(value);
+            if (Number.isNaN(parsed.getTime())) throw new Error(`Invalid timestamp format: ${value}`);
+            return parsed;
+        }
+        if (typeof value === 'number') {
+            const excelEpoch = new Date(1899, 11, 30);
+            return new Date(excelEpoch.getTime() + value * 24 * 60 * 60 * 1000);
+        }
+        throw new Error(`Unable to parse timestamp: ${value}`);
+    },
+    Manager: (value: any): string => {
+        if (!value) throw new Error('Manager is required');
+        return String(value).trim();
+    },
+    Division: (value: any): string => (value ? String(value).trim() : ''),
+    Gameweek: (value: any): number => {
+        const parsed = Number.parseInt(String(value), 10);
+        if (Number.isNaN(parsed)) throw new Error(`Invalid Gameweek: ${value}`);
+        return parsed;
+    },
+    Stage: (value: any): string => {
+        if (!value) throw new Error('Stage is required');
+        return String(value).trim().toLowerCase();
+    },
+    Leg: (value: any): number => {
+        const parsed = Number.parseInt(String(value), 10);
+        return Number.isNaN(parsed) ? 1 : parsed;
+    },
+    Players: (value: any): number[] => {
+        if (!value) return [];
+        return String(value)
+            .split(',')
+            .map((code) => Number.parseInt(code.trim(), 10))
+            .filter((code) => !Number.isNaN(code));
+    },
+    SubmittedByAdmin: (value: any): boolean => {
+        if (typeof value === 'boolean') return value;
+        const normalized = String(value).trim().toLowerCase();
+        return normalized === 'true' || normalized === 'yes' || normalized === 'y' || normalized === '1';
+    },
+    AdminReason: (value: any): string => (value ? String(value).trim() : ''),
+};
+
+async function originalReadCupSubmissions(): Promise<ProcessedCupSheetData[]> {
+    try {
+        const sheetResult = await readDataFromSheet<Record<string, any>>(CUP_SHEET_NAME, {
+            headerOrder: [...CUP_SHEET_HEADERS],
+            transformFunctions: CUP_TRANSFORM_FUNCTIONS,
+            requireAllHeaders: true,
+            warnMissingHeaders: true,
+        });
+
+        return sheetResult.map((row) => ({
+            status: row.Status,
+            timestamp: row.Timestamp,
+            manager: row.Manager,
+            division: row.Division as DivisionId,
+            gameweek: row.Gameweek,
+            stage: row.Stage as CupStageId,
+            leg: row.Leg,
+            players: row.Players,
+            submittedByAdmin: row.SubmittedByAdmin,
+            adminReason: row.AdminReason,
+        }));
+    } catch (error) {
+        throw createAppError('CUP_READ_ERROR', 'Failed to read cup submissions from sheet', error);
+    }
+}
+
+export async function readCupSubmissions(): Promise<ProcessedCupSheetData[]> {
+    return await dataCache.get(CACHE_KEYS.SHEETS.CUP, () => originalReadCupSubmissions(), {
+        ttlMs: getCacheTTL(CACHE_KEYS.SHEETS.CUP),
+    });
+}
+
+export async function addCupSubmission(submission: ProcessedCupSheetData): Promise<void> {
+    try {
+        const spreadsheetId = process.env.GOOGLE_SHEETS_ID as string;
+        const cacheKey = `${spreadsheetId}:${CUP_SHEET_NAME}`;
+
+        let headers = getCachedHeaders(cacheKey);
+        if (!headers) {
+            const headerRange: SheetRange = { spreadsheetId, range: `'${CUP_SHEET_NAME}'!1:1` };
+            const headerData = await readSheetRange(headerRange);
+            headers = headerData.length > 0 ? headerData[0] : [];
+            setCachedHeaders(cacheKey, headers);
+        }
+
+        if (headers.length === 0) {
+            throw new Error('No headers found in cup sheet');
+        }
+
+        // Serialise the player-code array back to a comma-separated cell value.
+        const row = { ...submission, players: submission.players.join(',') };
+        const rows = convertToRowsWithHeaders([row], headers, CUP_HEADERS);
+
+        const sheetRange: SheetRange = {
+            spreadsheetId,
+            range: `'${CUP_SHEET_NAME}'!A:${String.fromCharCode(64 + headers.length)}`,
+        };
+
+        await appendToSheet(sheetRange, rows);
+        dataCache.invalidate(CACHE_KEYS.SHEETS.CUP);
+    } catch (error) {
+        throw createAppError('CUP_ADD_ERROR', 'Failed to add cup submission to sheet', error);
+    }
+}
+
+/**
+ * The stage->gameweek config is stored as key/value rows in the CupConfig tab.
+ * Parsing/serialising lives in cup-config.ts (pure, unit-tested); this layer
+ * only handles the sheet I/O and caching.
+ */
+async function originalReadCupConfig(): Promise<CupConfig> {
+    try {
+        const spreadsheetId = process.env.GOOGLE_SHEETS_ID as string;
+        const range: SheetRange = { spreadsheetId, range: `'${CUP_CONFIG_SHEET_NAME}'!A:B` };
+        const rows = await readSheetRange(range);
+
+        // Skip the header row; map [key, value] pairs.
+        const configRows = rows
+            .slice(1)
+            .filter((row) => row.length >= 2)
+            .map((row) => ({ key: String(row[0]), value: String(row[1]) }));
+
+        return parseCupConfig(configRows);
+    } catch (error) {
+        throw createAppError('CUP_CONFIG_READ_ERROR', 'Failed to read cup config from sheet', error);
+    }
+}
+
+export async function readCupConfig(): Promise<CupConfig> {
+    return await dataCache.get(CACHE_KEYS.SHEETS.CUP_CONFIG, () => originalReadCupConfig(), {
+        ttlMs: getCacheTTL(CACHE_KEYS.SHEETS.CUP_CONFIG),
+    });
+}
+
+export async function writeCupConfig(config: CupConfig): Promise<void> {
+    try {
+        const spreadsheetId = process.env.GOOGLE_SHEETS_ID as string;
+        const rows = [['Key', 'Value'], ...serializeCupConfig(config).map((r) => [r.key, r.value])];
+        const range: SheetRange = { spreadsheetId, range: `'${CUP_CONFIG_SHEET_NAME}'!A:B` };
+        await appendToSheet(range, rows);
+        dataCache.invalidate(CACHE_KEYS.SHEETS.CUP_CONFIG);
+        dataCache.invalidate(CACHE_KEYS.SHEETS.CUP);
+    } catch (error) {
+        throw createAppError('CUP_CONFIG_WRITE_ERROR', 'Failed to write cup config to sheet', error);
+    }
+}

--- a/draft/app/_shared/lib/sheets/cup.ts
+++ b/draft/app/_shared/lib/sheets/cup.ts
@@ -1,17 +1,24 @@
 /* Location: app/_shared/lib/sheets/cup.ts */
 
 import { parseCupConfig, serializeCupConfig } from '../../../cup/lib/cup-config';
-import type { CupConfig, CupSheetData, CupStageId, ProcessedCupSheetData } from '../../../cup/types/cup-types';
-import type { DivisionId } from '../../../teams/types/team-types';
+import type {
+    CupConfig,
+    CupMatchup,
+    CupSheetData,
+    CupStageId,
+    ProcessedCupSheetData,
+} from '../../../cup/types/cup-types';
+import type { DivisionId, ManagerId } from '../../../teams/types/team-types';
 import { CACHE_KEYS, getCacheTTL } from '../cache/cache-config';
 import { dataCache } from '../cache/data-cache.service';
 import { convertToRowsWithHeaders, getCachedHeaders, setCachedHeaders } from './cache/utils';
-import { appendToSheet, createAppError, readSheetRange, type SheetRange } from './utils/common';
+import { appendToSheet, createAppError, readSheetRange, type SheetRange, writeSheetRange } from './utils/common';
 import { readDataFromSheet } from './utils/read-data-from-sheets';
 
 // The cup is cross-division, so submissions live in a single tab (not per-division).
 const CUP_SHEET_NAME = 'Cup';
 const CUP_CONFIG_SHEET_NAME = 'CupConfig';
+const CUP_BRACKET_SHEET_NAME = 'CupBracket';
 
 const CUP_HEADERS: Record<keyof CupSheetData, keyof ProcessedCupSheetData> = {
     Status: 'status',
@@ -189,11 +196,77 @@ export async function writeCupConfig(config: CupConfig): Promise<void> {
     try {
         const spreadsheetId = process.env.GOOGLE_SHEETS_ID as string;
         const rows = [['Key', 'Value'], ...serializeCupConfig(config).map((r) => [r.key, r.value])];
+        // Overwrite (not append) so the config is a single authoritative block.
         const range: SheetRange = { spreadsheetId, range: `'${CUP_CONFIG_SHEET_NAME}'!A:B` };
-        await appendToSheet(range, rows);
+        await writeSheetRange(range, rows);
         dataCache.invalidate(CACHE_KEYS.SHEETS.CUP_CONFIG);
         dataCache.invalidate(CACHE_KEYS.SHEETS.CUP);
     } catch (error) {
         throw createAppError('CUP_CONFIG_WRITE_ERROR', 'Failed to write cup config to sheet', error);
+    }
+}
+
+const CUP_BRACKET_HEADERS = ['Stage', 'Tie', 'Home', 'Away', 'HomeAggregate', 'AwayAggregate', 'Winner'] as const;
+
+function toManagerId(value: unknown): ManagerId | null {
+    const str = value === undefined || value === null ? '' : String(value).trim();
+    return str === '' ? null : str;
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+async function originalReadCupBracket(): Promise<CupMatchup[]> {
+    try {
+        const spreadsheetId = process.env.GOOGLE_SHEETS_ID as string;
+        const range: SheetRange = { spreadsheetId, range: `'${CUP_BRACKET_SHEET_NAME}'!A:G` };
+        const rows = await readSheetRange(range);
+
+        return rows
+            .slice(1)
+            .filter((row) => row.length > 0 && String(row[0]).trim() !== '')
+            .map((row) => ({
+                stage: String(row[0]).trim() as CupStageId,
+                tie: Number(row[1]) || 0,
+                home: toManagerId(row[2]),
+                away: toManagerId(row[3]),
+                homeAggregate: toOptionalNumber(row[4]),
+                awayAggregate: toOptionalNumber(row[5]),
+                winner: toManagerId(row[6]) ?? undefined,
+            }));
+    } catch (error) {
+        throw createAppError('CUP_BRACKET_READ_ERROR', 'Failed to read cup bracket from sheet', error);
+    }
+}
+
+export async function readCupBracket(): Promise<CupMatchup[]> {
+    return await dataCache.get(CACHE_KEYS.SHEETS.CUP_BRACKET, () => originalReadCupBracket(), {
+        ttlMs: getCacheTTL(CACHE_KEYS.SHEETS.CUP_BRACKET),
+    });
+}
+
+export async function writeCupBracket(matchups: CupMatchup[]): Promise<void> {
+    try {
+        const spreadsheetId = process.env.GOOGLE_SHEETS_ID as string;
+        const rows = [
+            [...CUP_BRACKET_HEADERS],
+            ...matchups.map((m) => [
+                m.stage,
+                m.tie,
+                m.home ?? '',
+                m.away ?? '',
+                m.homeAggregate ?? '',
+                m.awayAggregate ?? '',
+                m.winner ?? '',
+            ]),
+        ];
+        const range: SheetRange = { spreadsheetId, range: `'${CUP_BRACKET_SHEET_NAME}'!A:G` };
+        await writeSheetRange(range, rows);
+        dataCache.invalidate(CACHE_KEYS.SHEETS.CUP_BRACKET);
+    } catch (error) {
+        throw createAppError('CUP_BRACKET_WRITE_ERROR', 'Failed to write cup bracket to sheet', error);
     }
 }

--- a/draft/app/_shared/lib/sheets/player-gw-points.ts
+++ b/draft/app/_shared/lib/sheets/player-gw-points.ts
@@ -131,34 +131,26 @@ export async function writePlayerGameweekPointsToSheet(): Promise<void> {
  */
 export async function readPlayerGameweekPointsFromSheet(): Promise<PlayerGameweekPointsRow[]> {
     try {
-        const { headers, data: dataRows } = await readDataFromSheetWithHeaders(PLAYER_GW_POINTS_SHEET_NAME);
+        // readDataFromSheetWithHeaders already returns objects keyed by header name.
+        const { data: dataRows } =
+            await readDataFromSheetWithHeaders<Record<string, unknown>>(PLAYER_GW_POINTS_SHEET_NAME);
         if (dataRows.length === 0) return [];
 
-        // Parse data into objects
         return dataRows.map((row) => {
             const rowData: PlayerGameweekPointsRow = {
-                playerCode: 0,
-                webName: '',
-                teamName: '',
-                position: '',
+                playerCode: Number(row.playerCode) || 0,
+                webName: String(row.webName ?? ''),
+                teamName: String(row.teamName ?? ''),
+                position: String(row.position ?? ''),
             };
 
-            headers.forEach((header: string, index: number) => {
-                const value = row[index] || '';
-
-                if (header === 'playerCode') {
-                    rowData.playerCode = value;
-                } else if (header === 'webName') {
-                    rowData.webName = value.toString();
-                } else if (header === 'teamName') {
-                    rowData.team = value.toString();
-                } else if (header === 'position') {
-                    rowData.position = value.toString();
-                } else if (header.startsWith('gw-')) {
-                    // Parse round points columns
-                    rowData[header] = typeof value === 'number' ? value : Number.parseFloat(value.toString()) || 0;
+            // Copy every gameweek points column (gw-1, gw-2, …) as a number.
+            for (const key of Object.keys(row)) {
+                if (key.startsWith('gw-')) {
+                    const value = row[key];
+                    rowData[key] = typeof value === 'number' ? value : Number.parseFloat(String(value)) || 0;
                 }
-            });
+            }
 
             return rowData;
         });

--- a/draft/app/cup/components/cup-fixtures.module.css
+++ b/draft/app/cup/components/cup-fixtures.module.css
@@ -1,0 +1,46 @@
+/* Location: app/cup/components/cup-fixtures.module.css */
+
+.fixtures {
+    margin-bottom: var(--spacing-6);
+}
+
+.title {
+    margin: 0 0 var(--spacing-3) 0;
+    font-size: var(--font-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: var(--spacing-1);
+}
+
+.fixture {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-gray-50);
+    font-size: var(--font-sm);
+}
+
+.team {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-900);
+}
+
+.team:last-child {
+    text-align: right;
+}
+
+.score {
+    color: var(--color-gray-500);
+    font-variant-numeric: tabular-nums;
+}

--- a/draft/app/cup/components/cup-fixtures.tsx
+++ b/draft/app/cup/components/cup-fixtures.tsx
@@ -1,0 +1,25 @@
+/* Location: app/cup/components/cup-fixtures.tsx */
+
+import type { CupFixture } from '../lib/cup-fixtures';
+import styles from './cup-fixtures.module.css';
+
+/** The real-world fixtures for a gameweek, shown on the cup and submit pages. */
+export function CupFixtures({ fixtures, gameweek }: { fixtures: CupFixture[]; gameweek: number }) {
+    if (fixtures.length === 0) return null;
+    return (
+        <section className={styles.fixtures}>
+            <h2 className={styles.title}>Fixtures · GW{gameweek}</h2>
+            <ul className={styles.list}>
+                {fixtures.map((fixture) => (
+                    <li key={`${fixture.home}-${fixture.away}`} className={styles.fixture}>
+                        <span className={styles.team}>{fixture.home}</span>
+                        <span className={styles.score}>
+                            {fixture.started ? `${fixture.homeScore}–${fixture.awayScore}` : 'v'}
+                        </span>
+                        <span className={styles.team}>{fixture.away}</span>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/draft/app/cup/cup-admin.module.css
+++ b/draft/app/cup/cup-admin.module.css
@@ -6,13 +6,6 @@
     padding: var(--spacing-4);
 }
 
-.title {
-    margin: 0 0 var(--spacing-4) 0;
-    font-size: var(--font-2xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-gray-900);
-}
-
 .section {
     margin-bottom: var(--spacing-8);
     padding: var(--spacing-4);

--- a/draft/app/cup/cup-admin.module.css
+++ b/draft/app/cup/cup-admin.module.css
@@ -1,0 +1,125 @@
+/* Location: app/cup/cup-admin.module.css */
+
+.page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--spacing-4);
+}
+
+.title {
+    margin: 0 0 var(--spacing-4) 0;
+    font-size: var(--font-2xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-gray-900);
+}
+
+.section {
+    margin-bottom: var(--spacing-8);
+    padding: var(--spacing-4);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-md);
+}
+
+.sectionTitle {
+    margin: 0 0 var(--spacing-2) 0;
+    font-size: var(--font-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.hint {
+    margin: 0 0 var(--spacing-3) 0;
+    font-size: var(--font-sm);
+    color: var(--color-gray-600);
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+}
+
+.label {
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-700);
+}
+
+.input {
+    padding: var(--spacing-2);
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-sm);
+}
+
+.button {
+    align-self: flex-start;
+    padding: var(--spacing-2) var(--spacing-4);
+    border: none;
+    border-radius: var(--radius-md);
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    transition: background-color var(--transition-fast);
+}
+
+.button:hover {
+    background-color: var(--color-primary-hover);
+}
+
+.button:disabled {
+    background-color: var(--color-gray-300);
+    cursor: not-allowed;
+}
+
+.error {
+    padding: var(--spacing-3);
+    border-radius: var(--radius-md);
+    background-color: var(--color-error-light);
+    color: var(--color-error-text);
+    font-size: var(--font-sm);
+}
+
+.success {
+    padding: var(--spacing-3);
+    border-radius: var(--radius-md);
+    background-color: var(--color-success-light);
+    color: var(--color-success-text);
+    font-size: var(--font-sm);
+}
+
+.bracket {
+    list-style: none;
+    margin: var(--spacing-4) 0 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+}
+
+.tie {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-gray-50);
+    font-size: var(--font-sm);
+}
+
+.vs {
+    color: var(--color-gray-400);
+}
+
+.winner {
+    margin-left: auto;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-success-text);
+}

--- a/draft/app/cup/cup-admin.page.tsx
+++ b/draft/app/cup/cup-admin.page.tsx
@@ -1,6 +1,7 @@
 /* Location: app/cup/cup-admin.page.tsx */
 
 import { Form, useActionData, useLoaderData, useNavigation } from 'react-router';
+import { PageHeader } from '../_shared/components/page-header';
 import styles from './cup-admin.module.css';
 import type { CupAdminPageData } from './types/cup-page-types';
 
@@ -19,7 +20,7 @@ export function CupAdminPage() {
 
     return (
         <div className={styles.page}>
-            <h1 className={styles.title}>Cup Admin</h1>
+            <PageHeader title="Cup Admin" />
 
             {actionData?.error && <p className={styles.error}>{actionData.error}</p>}
             {actionData?.success && <p className={styles.success}>{actionData.message}</p>}

--- a/draft/app/cup/cup-admin.page.tsx
+++ b/draft/app/cup/cup-admin.page.tsx
@@ -1,0 +1,99 @@
+/* Location: app/cup/cup-admin.page.tsx */
+
+import { Form, useActionData, useLoaderData, useNavigation } from 'react-router';
+import styles from './cup-admin.module.css';
+import type { CupAdminPageData } from './types/cup-page-types';
+
+interface CupAdminActionData {
+    success?: boolean;
+    error?: string;
+    message?: string;
+}
+
+export function CupAdminPage() {
+    const data = useLoaderData<CupAdminPageData>();
+    const actionData = useActionData<CupAdminActionData>();
+    const navigation = useNavigation();
+    const config = data.config;
+    const isBusy = navigation.state !== 'idle';
+
+    return (
+        <div className={styles.page}>
+            <h1 className={styles.title}>Cup Admin</h1>
+
+            {actionData?.error && <p className={styles.error}>{actionData.error}</p>}
+            {actionData?.success && <p className={styles.success}>{actionData.message}</p>}
+
+            <section className={styles.section}>
+                <h2 className={styles.sectionTitle}>Stage gameweeks</h2>
+                <p className={styles.hint}>
+                    Map each cup stage to its FPL gameweek(s). These drive every deadline, submission window and score
+                    across the cup. Enter comma-separated gameweeks for the league stage and each two-leg round.
+                </p>
+                <Form method="post" className={styles.form}>
+                    <input type="hidden" name="actionType" value="setConfig" />
+                    <label className={styles.field}>
+                        <span className={styles.label}>Season</span>
+                        <input className={styles.input} name="season" defaultValue={config?.season ?? ''} />
+                    </label>
+                    <label className={styles.field}>
+                        <span className={styles.label}>League gameweeks</span>
+                        <input className={styles.input} name="league" defaultValue={config?.league.join(',') ?? ''} />
+                    </label>
+                    <label className={styles.field}>
+                        <span className={styles.label}>Round of 16 (leg 1, leg 2)</span>
+                        <input className={styles.input} name="r16" defaultValue={config?.r16.join(',') ?? ''} />
+                    </label>
+                    <label className={styles.field}>
+                        <span className={styles.label}>Quarter final (leg 1, leg 2)</span>
+                        <input className={styles.input} name="qf" defaultValue={config?.qf.join(',') ?? ''} />
+                    </label>
+                    <label className={styles.field}>
+                        <span className={styles.label}>Semi final (leg 1, leg 2)</span>
+                        <input className={styles.input} name="sf" defaultValue={config?.sf.join(',') ?? ''} />
+                    </label>
+                    <label className={styles.field}>
+                        <span className={styles.label}>Final gameweek</span>
+                        <input
+                            className={styles.input}
+                            name="final"
+                            defaultValue={config ? String(config.final) : ''}
+                        />
+                    </label>
+                    <button type="submit" className={styles.button} disabled={isBusy}>
+                        Save gameweeks
+                    </button>
+                </Form>
+            </section>
+
+            <section className={styles.section}>
+                <h2 className={styles.sectionTitle}>Round of 16 draw</h2>
+                <p className={styles.hint}>
+                    {data.qualifiers.length} qualifier{data.qualifiers.length === 1 ? '' : 's'} so far. Generating the
+                    draw randomly pairs the top 16 and overwrites any existing bracket.
+                </p>
+                <Form method="post">
+                    <input type="hidden" name="actionType" value="generateDraw" />
+                    <button type="submit" className={styles.button} disabled={isBusy || data.qualifiers.length < 2}>
+                        Generate R16 draw
+                    </button>
+                </Form>
+
+                {data.bracket.length > 0 && (
+                    <ul className={styles.bracket}>
+                        {data.bracket.map((matchup) => (
+                            <li key={`${matchup.stage}-${matchup.tie}`} className={styles.tie}>
+                                <span>{matchup.home ?? 'TBC'}</span>
+                                <span className={styles.vs}>v</span>
+                                <span>{matchup.away ?? 'BYE'}</span>
+                                {matchup.winner && <span className={styles.winner}>→ {matchup.winner}</span>}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    );
+}
+
+export default CupAdminPage;

--- a/draft/app/cup/cup-admin.route.tsx
+++ b/draft/app/cup/cup-admin.route.tsx
@@ -1,0 +1,106 @@
+/* Location: app/cup/cup-admin.route.tsx */
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { data } from 'react-router';
+import { requestFormData } from '../_shared/lib/form-data';
+import {
+    readCupBracket,
+    readCupConfig,
+    readCupSubmissions,
+    writeCupBracket,
+    writeCupConfig,
+} from '../_shared/lib/sheets/cup';
+import { readPlayerGameweekPointsFromSheet } from '../_shared/lib/sheets/player-gw-points';
+import { readUserTeams } from '../_shared/lib/sheets/user-teams';
+import { CupAdminPage } from './cup-admin.page';
+import { fisherYatesShuffle, pairIntoMatchups } from './lib/knockout';
+import type { CupAdminPageData } from './types/cup-page-types';
+import type { CupConfig } from './types/cup-types';
+
+export const meta: MetaFunction = () => [{ title: 'Cup Admin - Fantasy Football Draft' }];
+
+interface CupAdminActionData {
+    success?: boolean;
+    error?: string;
+    message?: string;
+}
+
+function parseGameweekList(value: string): number[] {
+    return value
+        .split(',')
+        .map((part) => Number.parseInt(part.trim(), 10))
+        .filter((n) => !Number.isNaN(n));
+}
+
+export async function loader(_args: LoaderFunctionArgs) {
+    try {
+        const [config, bracket, submissions, pointsRows, userTeams] = await Promise.all([
+            readCupConfig().catch(() => null),
+            readCupBracket().catch(() => []),
+            readCupSubmissions(),
+            readPlayerGameweekPointsFromSheet(),
+            readUserTeams(),
+        ]);
+
+        let qualifiers: CupAdminPageData['qualifiers'] = [];
+        if (config) {
+            const { getCupStandings } = await import('./server/cup.server');
+            qualifiers = getCupStandings({ userTeams, cupConfig: config, submissions, pointsRows }).qualifiers;
+        }
+
+        return data<CupAdminPageData>({ config, qualifiers, bracket });
+    } catch (error) {
+        console.error('Cup admin loader error:', error);
+        return data<CupAdminPageData>({ config: null, qualifiers: [], bracket: [] });
+    }
+}
+
+export async function action({ request, context }: ActionFunctionArgs) {
+    try {
+        const formData = await requestFormData({ request, context });
+        const actionType = String(formData.get('actionType') ?? '');
+
+        if (actionType === 'setConfig') {
+            const config: CupConfig = {
+                season: String(formData.get('season') ?? ''),
+                league: parseGameweekList(String(formData.get('league') ?? '')),
+                r16: parseGameweekList(String(formData.get('r16') ?? '')).slice(0, 2) as [number, number],
+                qf: parseGameweekList(String(formData.get('qf') ?? '')).slice(0, 2) as [number, number],
+                sf: parseGameweekList(String(formData.get('sf') ?? '')).slice(0, 2) as [number, number],
+                final: Number.parseInt(String(formData.get('final') ?? ''), 10),
+            };
+            await writeCupConfig(config);
+            return data<CupAdminActionData>({ success: true, message: 'Cup gameweeks saved.' });
+        }
+
+        if (actionType === 'generateDraw') {
+            const [config, submissions, pointsRows, userTeams] = await Promise.all([
+                readCupConfig(),
+                readCupSubmissions(),
+                readPlayerGameweekPointsFromSheet(),
+                readUserTeams(),
+            ]);
+            const { getCupStandings } = await import('./server/cup.server');
+            const { qualifiers } = getCupStandings({ userTeams, cupConfig: config, submissions, pointsRows });
+            if (qualifiers.length < 2) {
+                return data<CupAdminActionData>({ success: false, error: 'Not enough qualifiers to draw yet.' });
+            }
+            const order = fisherYatesShuffle(
+                qualifiers.map((q) => q.manager),
+                () => Math.random(),
+            );
+            await writeCupBracket(pairIntoMatchups(order, 'r16'));
+            return data<CupAdminActionData>({ success: true, message: 'Round of 16 draw generated.' });
+        }
+
+        return data<CupAdminActionData>({ success: false, error: `Unknown action: ${actionType}` });
+    } catch (error) {
+        console.error('Cup admin action error:', error);
+        return data<CupAdminActionData>({
+            success: false,
+            error: error instanceof Error ? error.message : 'Cup admin action failed',
+        });
+    }
+}
+
+export default CupAdminPage;

--- a/draft/app/cup/cup-submit.module.css
+++ b/draft/app/cup/cup-submit.module.css
@@ -1,0 +1,179 @@
+/* Location: app/cup/cup-submit.module.css */
+
+.page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--spacing-4);
+}
+
+.header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-2);
+}
+
+.title {
+    margin: 0;
+    font-size: var(--font-2xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-gray-900);
+}
+
+.roundLabel {
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary);
+}
+
+.deadline {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    margin: var(--spacing-3) 0;
+    font-size: var(--font-sm);
+    color: var(--color-gray-700);
+}
+
+.deadlineLabel {
+    font-weight: var(--font-weight-semibold);
+}
+
+.deadlineValue {
+    color: var(--color-gray-900);
+}
+
+.open {
+    color: var(--color-success-text);
+    font-weight: var(--font-weight-semibold);
+}
+
+.closed {
+    color: var(--color-error-text);
+    font-weight: var(--font-weight-semibold);
+}
+
+.notice {
+    padding: var(--spacing-4);
+    border-radius: var(--radius-md);
+    background-color: var(--color-gray-100);
+    color: var(--color-gray-700);
+    font-size: var(--font-sm);
+}
+
+.error {
+    padding: var(--spacing-3);
+    border-radius: var(--radius-md);
+    background-color: var(--color-error-light);
+    color: var(--color-error-text);
+    font-size: var(--font-sm);
+}
+
+.success {
+    padding: var(--spacing-3);
+    border-radius: var(--radius-md);
+    background-color: var(--color-success-light);
+    color: var(--color-success-text);
+    font-size: var(--font-sm);
+}
+
+.counter {
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-600);
+}
+
+.squad {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: var(--spacing-2);
+    margin-bottom: var(--spacing-4);
+}
+
+.player {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-1);
+    padding: var(--spacing-2) var(--spacing-3);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-md);
+    background-color: var(--color-white);
+    cursor: pointer;
+    transition:
+        border-color var(--transition-fast),
+        background-color var(--transition-fast);
+}
+
+.player:hover {
+    border-color: var(--color-primary);
+}
+
+.player:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.player.selected {
+    border-color: var(--color-primary);
+    background-color: var(--color-primary-light);
+}
+
+.player.used {
+    background-color: var(--color-gray-100);
+}
+
+.playerName {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-900);
+}
+
+.playerPosition {
+    font-size: var(--font-xs);
+    text-transform: uppercase;
+    color: var(--color-gray-500);
+}
+
+.pendingBadge {
+    font-size: var(--font-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-info);
+}
+
+.usedBadge {
+    font-size: var(--font-xs);
+    color: var(--color-gray-500);
+}
+
+.submit {
+    padding: var(--spacing-3) var(--spacing-6);
+    border: none;
+    border-radius: var(--radius-md);
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    transition: background-color var(--transition-fast);
+}
+
+.submit:hover {
+    background-color: var(--color-primary-hover);
+}
+
+.submit:disabled {
+    background-color: var(--color-gray-300);
+    cursor: not-allowed;
+}
+
+.backLink {
+    display: inline-block;
+    margin-top: var(--spacing-4);
+    color: var(--color-primary);
+    font-size: var(--font-sm);
+    text-decoration: none;
+}
+
+.backLink:hover {
+    text-decoration: underline;
+}

--- a/draft/app/cup/cup-submit.module.css
+++ b/draft/app/cup/cup-submit.module.css
@@ -27,6 +27,32 @@
     color: var(--color-primary);
 }
 
+.pickers {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+}
+
+.selector {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+}
+
+.label {
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-600);
+}
+
+.select {
+    padding: var(--spacing-2);
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-sm);
+    background-color: var(--color-white);
+}
+
 .deadline {
     display: flex;
     align-items: center;

--- a/draft/app/cup/cup-submit.module.css
+++ b/draft/app/cup/cup-submit.module.css
@@ -6,27 +6,6 @@
     padding: var(--spacing-4);
 }
 
-.header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-2);
-}
-
-.title {
-    margin: 0;
-    font-size: var(--font-2xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-gray-900);
-}
-
-.roundLabel {
-    font-size: var(--font-sm);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-primary);
-}
-
 .pickers {
     display: flex;
     align-items: center;

--- a/draft/app/cup/cup-submit.page.tsx
+++ b/draft/app/cup/cup-submit.page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Form, Link, useActionData, useLoaderData, useNavigation, useSearchParams } from 'react-router';
+import { PageHeader } from '../_shared/components/page-header';
 import { SelectUser } from '../_shared/components/select-user';
 import { setUserSelection } from '../_shared/features/user-selection/user-selection.utils';
 import { CupFixtures } from './components/cup-fixtures';
@@ -72,7 +73,7 @@ export function CupSubmitPage() {
     if (!data.selectedUserId) {
         return (
             <div className={styles.page}>
-                <h1 className={styles.title}>Submit Cup Team</h1>
+                <PageHeader title="Submit Cup Team" />
                 <p className={styles.notice}>Pick your manager to load your squad:</p>
                 {managerPicker}
                 <Link to="/cup" className={styles.backLink}>
@@ -85,7 +86,7 @@ export function CupSubmitPage() {
     if (!data.hasConfig || !data.round) {
         return (
             <div className={styles.page}>
-                <h1 className={styles.title}>Submit Cup Team</h1>
+                <PageHeader title="Submit Cup Team" />
                 <p className={styles.notice}>No cup round in that gameweek — pick a round to submit for:</p>
                 <div className={styles.pickers}>
                     {gameweekPicker}
@@ -99,22 +100,20 @@ export function CupSubmitPage() {
     }
 
     const stageLabel = CUP_STAGES[data.round.stage].label;
+    const subTitle = `${stageLabel}${data.round.twoLegged ? ` · Leg ${data.round.leg}` : ''}`;
 
     return (
         <div className={styles.page}>
-            <div className={styles.header}>
-                <div>
-                    <h1 className={styles.title}>Submit Cup Team</h1>
-                    <span className={styles.roundLabel}>
-                        {stageLabel}
-                        {data.round.twoLegged ? ` · Leg ${data.round.leg}` : ''}
-                    </span>
-                </div>
-                <div className={styles.pickers}>
-                    {gameweekPicker}
-                    {managerPicker}
-                </div>
-            </div>
+            <PageHeader
+                title="Submit Cup Team"
+                subTitle={subTitle}
+                actions={
+                    <>
+                        {gameweekPicker}
+                        {managerPicker}
+                    </>
+                }
+            />
 
             <div className={styles.deadline}>
                 <span className={styles.deadlineLabel}>Deadline:</span>

--- a/draft/app/cup/cup-submit.page.tsx
+++ b/draft/app/cup/cup-submit.page.tsx
@@ -1,7 +1,9 @@
 /* Location: app/cup/cup-submit.page.tsx */
 
 import { useState } from 'react';
-import { Form, Link, useActionData, useLoaderData, useNavigation } from 'react-router';
+import { Form, Link, useActionData, useLoaderData, useNavigation, useSearchParams } from 'react-router';
+import { SelectUser } from '../_shared/components/select-user';
+import { setUserSelection } from '../_shared/features/user-selection/user-selection.utils';
 import styles from './cup-submit.module.css';
 import { CUP_STAGES } from './lib/cup-rules';
 import type { CupSubmitPageData } from './types/cup-page-types';
@@ -16,6 +18,7 @@ export function CupSubmitPage() {
     const data = useLoaderData<CupSubmitPageData>();
     const actionData = useActionData<CupActionData>();
     const navigation = useNavigation();
+    const [searchParams, setSearchParams] = useSearchParams();
     const [selected, setSelected] = useState<number[]>(data.existingPlayers);
 
     const required = data.round?.playersRequired ?? 0;
@@ -30,11 +33,23 @@ export function CupSubmitPage() {
         });
     }
 
+    function handleUserChange(userId: string) {
+        setUserSelection(userId, false);
+        const next = new URLSearchParams(searchParams);
+        next.set('userId', userId);
+        setSearchParams(next);
+    }
+
+    const managerPicker = (
+        <SelectUser users={data.userTeams} selectedUser={data.selectedUserId} handleUserChange={handleUserChange} />
+    );
+
     if (!data.selectedUserId) {
         return (
             <div className={styles.page}>
                 <h1 className={styles.title}>Submit Cup Team</h1>
-                <p className={styles.notice}>Pick your manager from the menu first, then come back to submit.</p>
+                <p className={styles.notice}>Pick your manager to load your squad:</p>
+                {managerPicker}
                 <Link to="/cup" className={styles.backLink}>
                     Back to cup
                 </Link>
@@ -59,11 +74,14 @@ export function CupSubmitPage() {
     return (
         <div className={styles.page}>
             <div className={styles.header}>
-                <h1 className={styles.title}>Submit Cup Team</h1>
-                <span className={styles.roundLabel}>
-                    {stageLabel}
-                    {data.round.twoLegged ? ` · Leg ${data.round.leg}` : ''}
-                </span>
+                <div>
+                    <h1 className={styles.title}>Submit Cup Team</h1>
+                    <span className={styles.roundLabel}>
+                        {stageLabel}
+                        {data.round.twoLegged ? ` · Leg ${data.round.leg}` : ''}
+                    </span>
+                </div>
+                {managerPicker}
             </div>
 
             <div className={styles.deadline}>

--- a/draft/app/cup/cup-submit.page.tsx
+++ b/draft/app/cup/cup-submit.page.tsx
@@ -44,6 +44,30 @@ export function CupSubmitPage() {
         <SelectUser users={data.userTeams} selectedUser={data.selectedUserId} handleUserChange={handleUserChange} />
     );
 
+    function handleGameweekChange(gameweek: string) {
+        const next = new URLSearchParams(searchParams);
+        next.set('gameweek', gameweek);
+        setSearchParams(next);
+    }
+
+    const gameweekPicker =
+        data.gameweekOptions.length > 0 ? (
+            <label className={styles.selector}>
+                <span className={styles.label}>Round</span>
+                <select
+                    className={styles.select}
+                    value={data.selectedGameweek}
+                    onChange={(event) => handleGameweekChange(event.target.value)}
+                >
+                    {data.gameweekOptions.map((option) => (
+                        <option key={option.gameweek} value={option.gameweek}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </label>
+        ) : null;
+
     if (!data.selectedUserId) {
         return (
             <div className={styles.page}>
@@ -61,7 +85,11 @@ export function CupSubmitPage() {
         return (
             <div className={styles.page}>
                 <h1 className={styles.title}>Submit Cup Team</h1>
-                <p className={styles.notice}>There's no cup round open this gameweek.</p>
+                <p className={styles.notice}>No cup round in that gameweek — pick a round to submit for:</p>
+                <div className={styles.pickers}>
+                    {gameweekPicker}
+                    {managerPicker}
+                </div>
                 <Link to="/cup" className={styles.backLink}>
                     Back to cup
                 </Link>
@@ -81,7 +109,10 @@ export function CupSubmitPage() {
                         {data.round.twoLegged ? ` · Leg ${data.round.leg}` : ''}
                     </span>
                 </div>
-                {managerPicker}
+                <div className={styles.pickers}>
+                    {gameweekPicker}
+                    {managerPicker}
+                </div>
             </div>
 
             <div className={styles.deadline}>

--- a/draft/app/cup/cup-submit.page.tsx
+++ b/draft/app/cup/cup-submit.page.tsx
@@ -1,0 +1,129 @@
+/* Location: app/cup/cup-submit.page.tsx */
+
+import { useState } from 'react';
+import { Form, Link, useActionData, useLoaderData, useNavigation } from 'react-router';
+import styles from './cup-submit.module.css';
+import { CUP_STAGES } from './lib/cup-rules';
+import type { CupSubmitPageData } from './types/cup-page-types';
+
+interface CupActionData {
+    success?: boolean;
+    error?: string;
+    message?: string;
+}
+
+export function CupSubmitPage() {
+    const data = useLoaderData<CupSubmitPageData>();
+    const actionData = useActionData<CupActionData>();
+    const navigation = useNavigation();
+    const [selected, setSelected] = useState<number[]>(data.existingPlayers);
+
+    const required = data.round?.playersRequired ?? 0;
+    const usedPlayers = new Set(data.usedPlayers);
+    const isSubmitting = navigation.state === 'submitting';
+
+    function toggle(code: number) {
+        setSelected((current) => {
+            if (current.includes(code)) return current.filter((c) => c !== code);
+            if (current.length >= required) return current; // enforce the cap client-side
+            return [...current, code];
+        });
+    }
+
+    if (!data.selectedUserId) {
+        return (
+            <div className={styles.page}>
+                <h1 className={styles.title}>Submit Cup Team</h1>
+                <p className={styles.notice}>Pick your manager from the menu first, then come back to submit.</p>
+                <Link to="/cup" className={styles.backLink}>
+                    Back to cup
+                </Link>
+            </div>
+        );
+    }
+
+    if (!data.hasConfig || !data.round) {
+        return (
+            <div className={styles.page}>
+                <h1 className={styles.title}>Submit Cup Team</h1>
+                <p className={styles.notice}>There's no cup round open this gameweek.</p>
+                <Link to="/cup" className={styles.backLink}>
+                    Back to cup
+                </Link>
+            </div>
+        );
+    }
+
+    const stageLabel = CUP_STAGES[data.round.stage].label;
+
+    return (
+        <div className={styles.page}>
+            <div className={styles.header}>
+                <h1 className={styles.title}>Submit Cup Team</h1>
+                <span className={styles.roundLabel}>
+                    {stageLabel}
+                    {data.round.twoLegged ? ` · Leg ${data.round.leg}` : ''}
+                </span>
+            </div>
+
+            <div className={styles.deadline}>
+                <span className={styles.deadlineLabel}>Deadline:</span>
+                <span className={styles.deadlineValue}>{data.deadline}</span>
+                {data.submissionOpen ? (
+                    <span className={styles.open}>✓ Open</span>
+                ) : (
+                    <span className={styles.closed}>✗ Closed</span>
+                )}
+            </div>
+
+            {actionData?.error && <p className={styles.error}>{actionData.error}</p>}
+            {actionData?.success && <p className={styles.success}>{actionData.message}</p>}
+
+            <p className={styles.counter}>
+                Selected {selected.length} / {required}
+            </p>
+
+            <Form method="post">
+                <input type="hidden" name="manager" value={data.selectedUserId} />
+                <input type="hidden" name="division" value={data.division ?? ''} />
+                <input type="hidden" name="gameweek" value={data.round.gameweek} />
+                <input type="hidden" name="players" value={selected.join(',')} />
+
+                <div className={styles.squad}>
+                    {data.squad.map((player) => {
+                        const isUsed = usedPlayers.has(player.code);
+                        const isChecked = selected.includes(player.code);
+                        return (
+                            <button
+                                type="button"
+                                key={player.code}
+                                className={`${styles.player} ${isChecked ? styles.selected : ''} ${isUsed ? styles.used : ''}`}
+                                disabled={isUsed || !data.submissionOpen}
+                                onClick={() => toggle(player.code)}
+                            >
+                                <span className={styles.playerName}>{player.name}</span>
+                                <span className={styles.playerPosition}>{player.position}</span>
+                                {player.isPending && <span className={styles.pendingBadge}>pending</span>}
+                                {isUsed && <span className={styles.usedBadge}>used in leg 1</span>}
+                            </button>
+                        );
+                    })}
+                </div>
+
+                <button
+                    type="submit"
+                    className={styles.submit}
+                    disabled={isSubmitting || selected.length !== required || !data.submissionOpen}
+                >
+                    {isSubmitting ? 'Submitting…' : 'Submit team'}
+                </button>
+            </Form>
+
+            <Link to="/cup" className={styles.backLink}>
+                Back to cup
+            </Link>
+        </div>
+    );
+}
+
+export default CupSubmitPage;

--- a/draft/app/cup/cup-submit.page.tsx
+++ b/draft/app/cup/cup-submit.page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Form, Link, useActionData, useLoaderData, useNavigation, useSearchParams } from 'react-router';
 import { SelectUser } from '../_shared/components/select-user';
 import { setUserSelection } from '../_shared/features/user-selection/user-selection.utils';
+import { CupFixtures } from './components/cup-fixtures';
 import styles from './cup-submit.module.css';
 import { CUP_STAGES } from './lib/cup-rules';
 import type { CupSubmitPageData } from './types/cup-page-types';
@@ -124,6 +125,8 @@ export function CupSubmitPage() {
                     <span className={styles.closed}>✗ Closed</span>
                 )}
             </div>
+
+            <CupFixtures fixtures={data.fixtures} gameweek={data.selectedGameweek} />
 
             {actionData?.error && <p className={styles.error}>{actionData.error}</p>}
             {actionData?.success && <p className={styles.success}>{actionData.message}</p>}

--- a/draft/app/cup/cup-submit.route.tsx
+++ b/draft/app/cup/cup-submit.route.tsx
@@ -8,6 +8,7 @@ import { readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
 import { readUserTeams } from '../_shared/lib/sheets/user-teams';
 import type { DivisionId } from '../teams/types/team-types';
 import { CupSubmitPage } from './cup-submit.page';
+import { buildCupFixtures } from './lib/cup-fixtures';
 import { getCupSubmitData } from './server/cup.server';
 import type { CupSubmitPageData } from './types/cup-page-types';
 
@@ -23,10 +24,12 @@ interface CupActionData {
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
-    const [currentGameweekData, events, userTeams] = await Promise.all([
+    const [currentGameweekData, events, userTeams, fplFixtures, teams] = await Promise.all([
         fplApiCache.getCurrentGameweekData(),
         fplApiCache.getFplEvents(),
         readUserTeams(),
+        fplApiCache.getFplFixtures(),
+        fplApiCache.getFplTeams(),
     ]);
     const persistedUser = getUserSelection(request);
     const selectedUser = userTeams.find((team) => team.userId === persistedUser.selectedUserId);
@@ -45,6 +48,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
                 : (cupGameweeks[0] ?? currentId)
             : requested;
         const gameweekData = events.find((event) => event.fplEvent.id === selectedGameweek) ?? currentGameweekData;
+        const fixtures = buildCupFixtures(fplFixtures, teams, selectedGameweek);
 
         const pageData = await getCupSubmitData({
             userTeams,
@@ -52,6 +56,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             gameweekData,
             cupConfig,
             submissions,
+            fixtures,
         });
         return data<CupSubmitPageData>(pageData);
     } catch (error) {
@@ -70,6 +75,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             deadline: String(currentGameweekData.fplEvent.deadline_time),
             selectedGameweek: currentGameweekData.fplEvent.id,
             gameweekOptions: [],
+            fixtures: [],
         });
     }
 }

--- a/draft/app/cup/cup-submit.route.tsx
+++ b/draft/app/cup/cup-submit.route.tsx
@@ -1,0 +1,74 @@
+/* Location: app/cup/cup-submit.route.tsx */
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { data } from 'react-router';
+import { getUserSelection } from '../_shared/features/user-selection/user-selection.utils';
+import { requestFormData } from '../_shared/lib/form-data';
+import { readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
+import { readUserTeams } from '../_shared/lib/sheets/user-teams';
+import type { DivisionId } from '../teams/types/team-types';
+import { CupSubmitPage } from './cup-submit.page';
+import { getCupSubmitData } from './server/cup.server';
+import type { CupSubmitPageData } from './types/cup-page-types';
+
+export const meta: MetaFunction = () => {
+    return [{ title: 'Submit Cup Team - Fantasy Football Draft' }];
+};
+
+interface CupActionData {
+    success?: boolean;
+    error?: string;
+    message?: string;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+    const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
+    const [currentGameweekData, userTeams] = await Promise.all([fplApiCache.getCurrentGameweekData(), readUserTeams()]);
+    const persistedUser = getUserSelection(request);
+    const selectedUser = userTeams.find((team) => team.userId === persistedUser.selectedUserId);
+
+    try {
+        const [cupConfig, submissions] = await Promise.all([readCupConfig(), readCupSubmissions()]);
+        const pageData = await getCupSubmitData({ selectedUser, currentGameweekData, cupConfig, submissions });
+        return data<CupSubmitPageData>(pageData);
+    } catch (error) {
+        console.error('Cup submit loader error:', error);
+        return data<CupSubmitPageData>({
+            hasConfig: false,
+            round: null,
+            selectedUserId: selectedUser?.userId ?? null,
+            selectedUserName: selectedUser?.userName ?? null,
+            division: selectedUser?.divisionId ?? null,
+            squad: [],
+            existingPlayers: [],
+            usedPlayers: [],
+            submissionOpen: false,
+            deadline: String(currentGameweekData.fplEvent.deadline_time),
+        });
+    }
+}
+
+export async function action({ request, context }: ActionFunctionArgs) {
+    try {
+        const formData = await requestFormData({ request, context });
+        const manager = String(formData.get('manager') ?? '');
+        const division = String(formData.get('division') ?? '') as DivisionId;
+        const gameweek = Number.parseInt(String(formData.get('gameweek') ?? ''), 10);
+        const players = String(formData.get('players') ?? '')
+            .split(',')
+            .map((code) => Number.parseInt(code.trim(), 10))
+            .filter((code) => !Number.isNaN(code));
+
+        const { handleCupSubmission } = await import('./server/actions/submit-cup-team.action');
+        const result = await handleCupSubmission({ manager, division, gameweek, players });
+        return data<CupActionData>(result);
+    } catch (error) {
+        console.error('Cup submit action error:', error);
+        return data<CupActionData>({
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to submit cup team',
+        });
+    }
+}
+
+export default CupSubmitPage;

--- a/draft/app/cup/cup-submit.route.tsx
+++ b/draft/app/cup/cup-submit.route.tsx
@@ -23,16 +23,33 @@ interface CupActionData {
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
-    const [currentGameweekData, userTeams] = await Promise.all([fplApiCache.getCurrentGameweekData(), readUserTeams()]);
+    const [currentGameweekData, events, userTeams] = await Promise.all([
+        fplApiCache.getCurrentGameweekData(),
+        fplApiCache.getFplEvents(),
+        readUserTeams(),
+    ]);
     const persistedUser = getUserSelection(request);
     const selectedUser = userTeams.find((team) => team.userId === persistedUser.selectedUserId);
 
     try {
         const [cupConfig, submissions] = await Promise.all([readCupConfig(), readCupSubmissions()]);
+
+        // Same gameweek resolution as /cup: ?gameweek wins, else current-if-cup, else first cup gameweek.
+        const { resolveCupRounds } = await import('./lib/cup-config');
+        const cupGameweeks = resolveCupRounds(cupConfig).map((round) => round.gameweek);
+        const requested = Number.parseInt(new URL(request.url).searchParams.get('gameweek') ?? '', 10);
+        const currentId = currentGameweekData.fplEvent.id;
+        const selectedGameweek = Number.isNaN(requested)
+            ? cupGameweeks.includes(currentId)
+                ? currentId
+                : (cupGameweeks[0] ?? currentId)
+            : requested;
+        const gameweekData = events.find((event) => event.fplEvent.id === selectedGameweek) ?? currentGameweekData;
+
         const pageData = await getCupSubmitData({
             userTeams,
             selectedUser,
-            currentGameweekData,
+            gameweekData,
             cupConfig,
             submissions,
         });
@@ -51,6 +68,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
             usedPlayers: [],
             submissionOpen: false,
             deadline: String(currentGameweekData.fplEvent.deadline_time),
+            selectedGameweek: currentGameweekData.fplEvent.id,
+            gameweekOptions: [],
         });
     }
 }

--- a/draft/app/cup/cup-submit.route.tsx
+++ b/draft/app/cup/cup-submit.route.tsx
@@ -29,13 +29,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     try {
         const [cupConfig, submissions] = await Promise.all([readCupConfig(), readCupSubmissions()]);
-        const pageData = await getCupSubmitData({ selectedUser, currentGameweekData, cupConfig, submissions });
+        const pageData = await getCupSubmitData({
+            userTeams,
+            selectedUser,
+            currentGameweekData,
+            cupConfig,
+            submissions,
+        });
         return data<CupSubmitPageData>(pageData);
     } catch (error) {
         console.error('Cup submit loader error:', error);
         return data<CupSubmitPageData>({
             hasConfig: false,
             round: null,
+            userTeams,
             selectedUserId: selectedUser?.userId ?? null,
             selectedUserName: selectedUser?.userName ?? null,
             division: selectedUser?.divisionId ?? null,

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -6,34 +6,6 @@
     padding: var(--spacing-4);
 }
 
-.header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-2);
-    margin-bottom: var(--spacing-4);
-}
-
-.title {
-    margin: 0;
-    font-size: var(--font-2xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-gray-900);
-}
-
-.roundLabel {
-    font-size: var(--font-sm);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-primary);
-}
-
-.headerActions {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-3);
-}
-
 .selector {
     display: flex;
     align-items: center;

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -1,0 +1,95 @@
+/* Location: app/cup/cup.module.css */
+
+.page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: var(--spacing-4);
+}
+
+.header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-2);
+    margin-bottom: var(--spacing-4);
+}
+
+.title {
+    margin: 0;
+    font-size: var(--font-2xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-gray-900);
+}
+
+.roundLabel {
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary);
+}
+
+.submitLink {
+    display: inline-block;
+    padding: var(--spacing-2) var(--spacing-4);
+    border-radius: var(--radius-md);
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-weight: var(--font-weight-semibold);
+    text-decoration: none;
+    transition: background-color var(--transition-fast);
+}
+
+.submitLink:hover {
+    background-color: var(--color-primary-hover);
+}
+
+.notice {
+    padding: var(--spacing-4);
+    border-radius: var(--radius-md);
+    background-color: var(--color-gray-100);
+    color: var(--color-gray-700);
+    font-size: var(--font-sm);
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-sm);
+}
+
+.headerCell {
+    padding: var(--spacing-2);
+    border-bottom: 2px solid var(--color-gray-200);
+    color: var(--color-gray-600);
+    font-weight: var(--font-weight-semibold);
+    text-align: left;
+}
+
+.cell {
+    padding: var(--spacing-2);
+    border-bottom: 1px solid var(--color-gray-100);
+    color: var(--color-gray-900);
+}
+
+.managerName {
+    font-weight: var(--font-weight-medium);
+}
+
+.teamName {
+    display: block;
+    color: var(--color-gray-500);
+    font-size: var(--font-xs);
+}
+
+.revealed {
+    color: var(--color-success-text);
+    font-weight: var(--font-weight-medium);
+}
+
+.hidden {
+    color: var(--color-gray-500);
+}
+
+.pending {
+    color: var(--color-gray-400);
+}

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -28,6 +28,32 @@
     color: var(--color-primary);
 }
 
+.headerActions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+}
+
+.selector {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+}
+
+.selectorLabel {
+    font-size: var(--font-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-600);
+}
+
+.select {
+    padding: var(--spacing-2);
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-sm);
+    background-color: var(--color-white);
+}
+
 .submitLink {
     display: inline-block;
     padding: var(--spacing-2) var(--spacing-4);

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -120,6 +120,50 @@
     color: var(--color-gray-400);
 }
 
+.matchupList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+}
+
+.matchup {
+    display: grid;
+    grid-template-columns: 1fr auto auto auto 1fr;
+    align-items: center;
+    gap: var(--spacing-3);
+    padding: var(--spacing-3);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-md);
+}
+
+.matchupName {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-900);
+}
+
+.matchupName:first-child {
+    text-align: right;
+}
+
+.matchupWinner {
+    color: var(--color-success-text);
+    font-weight: var(--font-weight-bold);
+}
+
+.matchupScore {
+    min-width: var(--spacing-8);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-gray-700);
+}
+
+.vs {
+    color: var(--color-gray-400);
+}
+
 .qualifiers {
     margin-top: var(--spacing-8);
 }

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -120,6 +120,44 @@
     color: var(--color-gray-400);
 }
 
+.fixtures {
+    margin-bottom: var(--spacing-6);
+}
+
+.fixtureList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: var(--spacing-1);
+}
+
+.fixture {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-gray-50);
+    font-size: var(--font-sm);
+}
+
+.fixtureTeam {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-900);
+}
+
+.fixtureTeam:last-child {
+    text-align: right;
+}
+
+.fixtureScore {
+    color: var(--color-gray-500);
+    font-variant-numeric: tabular-nums;
+}
+
 .qualifiers {
     margin-top: var(--spacing-8);
 }

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -93,3 +93,43 @@
 .pending {
     color: var(--color-gray-400);
 }
+
+.qualifiers {
+    margin-top: var(--spacing-8);
+}
+
+.sectionTitle {
+    margin: 0 0 var(--spacing-3) 0;
+    font-size: var(--font-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.qualifierList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: var(--spacing-1);
+}
+
+.qualifierItem {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-gray-50);
+}
+
+.qualifierRank {
+    min-width: var(--spacing-6);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-primary);
+}
+
+.qualifierName {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-900);
+}

--- a/draft/app/cup/cup.module.css
+++ b/draft/app/cup/cup.module.css
@@ -120,44 +120,6 @@
     color: var(--color-gray-400);
 }
 
-.fixtures {
-    margin-bottom: var(--spacing-6);
-}
-
-.fixtureList {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    gap: var(--spacing-1);
-}
-
-.fixture {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--spacing-2);
-    padding: var(--spacing-2);
-    border-radius: var(--radius-sm);
-    background-color: var(--color-gray-50);
-    font-size: var(--font-sm);
-}
-
-.fixtureTeam {
-    font-weight: var(--font-weight-medium);
-    color: var(--color-gray-900);
-}
-
-.fixtureTeam:last-child {
-    text-align: right;
-}
-
-.fixtureScore {
-    color: var(--color-gray-500);
-    font-variant-numeric: tabular-nums;
-}
-
 .qualifiers {
     margin-top: var(--spacing-8);
 }

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -1,9 +1,34 @@
 /* Location: app/cup/cup.page.tsx */
 
-import { Link, useLoaderData } from 'react-router';
+import { Link, useLoaderData, useSearchParams } from 'react-router';
 import styles from './cup.module.css';
 import { CUP_STAGES } from './lib/cup-rules';
 import type { CupOverviewRow, CupPageData } from './types/cup-page-types';
+
+function GameweekSelector({ data }: { data: CupPageData }) {
+    const [searchParams, setSearchParams] = useSearchParams();
+    if (data.gameweekOptions.length === 0) return null;
+    return (
+        <label className={styles.selector}>
+            <span className={styles.selectorLabel}>Round</span>
+            <select
+                className={styles.select}
+                value={data.selectedGameweek}
+                onChange={(event) => {
+                    const next = new URLSearchParams(searchParams);
+                    next.set('gameweek', event.target.value);
+                    setSearchParams(next);
+                }}
+            >
+                {data.gameweekOptions.map((option) => (
+                    <option key={option.gameweek} value={option.gameweek}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        </label>
+    );
+}
 
 function StatusCell({ row }: { row: CupOverviewRow }) {
     if (row.visibility === 'revealed') {
@@ -66,9 +91,12 @@ export function CupPage() {
                         </span>
                     )}
                 </div>
-                <Link to="/cup/submit" className={styles.submitLink}>
-                    Submit my team
-                </Link>
+                <div className={styles.headerActions}>
+                    <GameweekSelector data={data} />
+                    <Link to="/cup/submit" className={styles.submitLink}>
+                        Submit my team
+                    </Link>
+                </div>
             </div>
 
             {data.hasConfig ? (

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -7,12 +7,29 @@ import type { CupOverviewRow, CupPageData } from './types/cup-page-types';
 
 function StatusCell({ row }: { row: CupOverviewRow }) {
     if (row.visibility === 'revealed') {
-        return <span className={styles.revealed}>{row.players?.length ?? 0} players submitted</span>;
+        return <span className={styles.revealed}>{row.points ?? 0} pts</span>;
     }
     if (row.visibility === 'submitted_hidden') {
         return <span className={styles.hidden}>🔒 Hidden until deadline</span>;
     }
     return <span className={styles.pending}>Not submitted</span>;
+}
+
+function QualifiersTable({ data }: { data: CupPageData }) {
+    if (data.qualifiers.length === 0) return null;
+    return (
+        <section className={styles.qualifiers}>
+            <h2 className={styles.sectionTitle}>Qualifiers (Round of 16)</h2>
+            <ol className={styles.qualifierList}>
+                {data.qualifiers.map((qualifier) => (
+                    <li key={qualifier.manager} className={styles.qualifierItem}>
+                        <span className={styles.qualifierRank}>{qualifier.rank}</span>
+                        <span className={styles.qualifierName}>{qualifier.userName}</span>
+                    </li>
+                ))}
+            </ol>
+        </section>
+    );
 }
 
 export function CupPage() {
@@ -65,6 +82,8 @@ export function CupPage() {
                     The cup isn't set up for this gameweek yet. An admin needs to map the cup stages to gameweeks.
                 </p>
             )}
+
+            <QualifiersTable data={data} />
         </div>
     );
 }

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -1,9 +1,31 @@
 /* Location: app/cup/cup.page.tsx */
 
 import { Link, useLoaderData, useSearchParams } from 'react-router';
+import { SelectUser } from '../_shared/components/select-user';
+import { setUserSelection } from '../_shared/features/user-selection/user-selection.utils';
 import styles from './cup.module.css';
 import { CUP_STAGES } from './lib/cup-rules';
 import type { CupOverviewRow, CupPageData } from './types/cup-page-types';
+
+function CupFixtures({ data }: { data: CupPageData }) {
+    if (data.fixtures.length === 0) return null;
+    return (
+        <section className={styles.fixtures}>
+            <h2 className={styles.sectionTitle}>Fixtures · GW{data.selectedGameweek}</h2>
+            <ul className={styles.fixtureList}>
+                {data.fixtures.map((fixture) => (
+                    <li key={`${fixture.home}-${fixture.away}`} className={styles.fixture}>
+                        <span className={styles.fixtureTeam}>{fixture.home}</span>
+                        <span className={styles.fixtureScore}>
+                            {fixture.started ? `${fixture.homeScore}–${fixture.awayScore}` : 'v'}
+                        </span>
+                        <span className={styles.fixtureTeam}>{fixture.away}</span>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}
 
 function GameweekSelector({ data }: { data: CupPageData }) {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -77,7 +99,15 @@ function QualifiersTable({ data }: { data: CupPageData }) {
 
 export function CupPage() {
     const data = useLoaderData<CupPageData>();
+    const [searchParams, setSearchParams] = useSearchParams();
     const stageLabel = data.round ? CUP_STAGES[data.round.stage].label : null;
+
+    function handleUserChange(userId: string) {
+        setUserSelection(userId, false); // persist to the cookie so /cup/submit sees it
+        const next = new URLSearchParams(searchParams);
+        next.set('userId', userId);
+        setSearchParams(next);
+    }
 
     return (
         <div className={styles.page}>
@@ -92,12 +122,19 @@ export function CupPage() {
                     )}
                 </div>
                 <div className={styles.headerActions}>
+                    <SelectUser
+                        users={data.userTeams}
+                        selectedUser={data.selectedUserId}
+                        handleUserChange={handleUserChange}
+                    />
                     <GameweekSelector data={data} />
                     <Link to="/cup/submit" className={styles.submitLink}>
                         Submit my team
                     </Link>
                 </div>
             </div>
+
+            <CupFixtures data={data} />
 
             {data.hasConfig ? (
                 <table className={styles.table}>

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -1,6 +1,7 @@
 /* Location: app/cup/cup.page.tsx */
 
 import { Link, useLoaderData, useSearchParams } from 'react-router';
+import { PageHeader } from '../_shared/components/page-header';
 import { SelectUser } from '../_shared/components/select-user';
 import { setUserSelection } from '../_shared/features/user-selection/user-selection.utils';
 import { CupFixtures } from './components/cup-fixtures';
@@ -114,30 +115,29 @@ export function CupPage() {
         setSearchParams(next);
     }
 
+    const subTitle = stageLabel
+        ? `${stageLabel}${data.round?.twoLegged ? ` · Leg ${data.round.leg}` : ''} · GW${data.gameweek}`
+        : undefined;
+
     return (
         <div className={styles.page}>
-            <div className={styles.header}>
-                <div>
-                    <h1 className={styles.title}>Cup</h1>
-                    {stageLabel && (
-                        <span className={styles.roundLabel}>
-                            {stageLabel}
-                            {data.round?.twoLegged ? ` · Leg ${data.round.leg}` : ''} · GW{data.gameweek}
-                        </span>
-                    )}
-                </div>
-                <div className={styles.headerActions}>
-                    <SelectUser
-                        users={data.userTeams}
-                        selectedUser={data.selectedUserId}
-                        handleUserChange={handleUserChange}
-                    />
-                    <GameweekSelector data={data} />
-                    <Link to={`/cup/submit?gameweek=${data.selectedGameweek}`} className={styles.submitLink}>
-                        Submit my team
-                    </Link>
-                </div>
-            </div>
+            <PageHeader
+                title="Cup"
+                subTitle={subTitle}
+                actions={
+                    <>
+                        <SelectUser
+                            users={data.userTeams}
+                            selectedUser={data.selectedUserId}
+                            handleUserChange={handleUserChange}
+                        />
+                        <GameweekSelector data={data} />
+                        <Link to={`/cup/submit?gameweek=${data.selectedGameweek}`} className={styles.submitLink}>
+                            Submit my team
+                        </Link>
+                    </>
+                }
+            />
 
             <CupFixtures fixtures={data.fixtures} gameweek={data.selectedGameweek} />
 

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -43,21 +43,44 @@ function StatusCell({ row }: { row: CupOverviewRow }) {
     return <span className={styles.pending}>Not submitted</span>;
 }
 
-function Bracket({ data }: { data: CupPageData }) {
-    if (data.bracket.length === 0) return null;
+function sideScore(points: number | null, aggregate: number | null): string {
+    if (aggregate !== null) return `${points ?? 0} (agg ${aggregate})`;
+    return points === null ? '–' : String(points);
+}
+
+function StageMatchups({ data }: { data: CupPageData }) {
+    const label = data.round ? CUP_STAGES[data.round.stage].label : '';
+    if (data.stageMatchups.length === 0) {
+        return (
+            <p className={styles.notice}>
+                The {label} draw hasn't been generated yet — an admin can create it from the cup admin page.
+            </p>
+        );
+    }
     return (
-        <section className={styles.qualifiers}>
-            <h2 className={styles.sectionTitle}>Knockout bracket</h2>
-            <ul className={styles.qualifierList}>
-                {data.bracket.map((matchup) => (
-                    <li key={`${matchup.stage}-${matchup.tie}`} className={styles.qualifierItem}>
-                        <span className={styles.qualifierName}>{matchup.home ?? 'TBC'}</span>
-                        <span className={styles.pending}>v</span>
-                        <span className={styles.qualifierName}>{matchup.away ?? 'BYE'}</span>
-                    </li>
-                ))}
-            </ul>
-        </section>
+        <ul className={styles.matchupList}>
+            {data.stageMatchups.map((matchup) => (
+                <li key={matchup.tie} className={styles.matchup}>
+                    <span
+                        className={`${styles.matchupName} ${matchup.winner && matchup.winner === matchup.home.manager ? styles.matchupWinner : ''}`}
+                    >
+                        {matchup.home.name}
+                    </span>
+                    <span className={styles.matchupScore}>
+                        {sideScore(matchup.home.points, matchup.home.aggregate)}
+                    </span>
+                    <span className={styles.vs}>v</span>
+                    <span className={styles.matchupScore}>
+                        {sideScore(matchup.away.points, matchup.away.aggregate)}
+                    </span>
+                    <span
+                        className={`${styles.matchupName} ${matchup.winner && matchup.winner === matchup.away.manager ? styles.matchupWinner : ''}`}
+                    >
+                        {matchup.away.name}
+                    </span>
+                </li>
+            ))}
+        </ul>
     );
 }
 
@@ -82,6 +105,7 @@ export function CupPage() {
     const data = useLoaderData<CupPageData>();
     const [searchParams, setSearchParams] = useSearchParams();
     const stageLabel = data.round ? CUP_STAGES[data.round.stage].label : null;
+    const isKnockout = !!data.round && data.round.stage !== 'league';
 
     function handleUserChange(userId: string) {
         setUserSelection(userId, false); // persist to the cookie so /cup/submit sees it
@@ -118,37 +142,40 @@ export function CupPage() {
             <CupFixtures fixtures={data.fixtures} gameweek={data.selectedGameweek} />
 
             {data.hasConfig ? (
-                <table className={styles.table}>
-                    <thead>
-                        <tr>
-                            <th className={styles.headerCell}>Manager</th>
-                            <th className={styles.headerCell}>Division</th>
-                            <th className={styles.headerCell}>Status</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {data.rows.map((row) => (
-                            <tr key={row.manager}>
-                                <td className={styles.cell}>
-                                    <span className={styles.managerName}>{row.userName}</span>
-                                    <span className={styles.teamName}>{row.teamName}</span>
-                                </td>
-                                <td className={styles.cell}>{row.division}</td>
-                                <td className={styles.cell}>
-                                    <StatusCell row={row} />
-                                </td>
+                isKnockout ? (
+                    <StageMatchups data={data} />
+                ) : (
+                    <table className={styles.table}>
+                        <thead>
+                            <tr>
+                                <th className={styles.headerCell}>Manager</th>
+                                <th className={styles.headerCell}>Division</th>
+                                <th className={styles.headerCell}>Status</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            {data.rows.map((row) => (
+                                <tr key={row.manager}>
+                                    <td className={styles.cell}>
+                                        <span className={styles.managerName}>{row.userName}</span>
+                                        <span className={styles.teamName}>{row.teamName}</span>
+                                    </td>
+                                    <td className={styles.cell}>{row.division}</td>
+                                    <td className={styles.cell}>
+                                        <StatusCell row={row} />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )
             ) : (
                 <p className={styles.notice}>
                     The cup isn't set up for this gameweek yet. An admin needs to map the cup stages to gameweeks.
                 </p>
             )}
 
-            <Bracket data={data} />
-            <QualifiersTable data={data} />
+            {!isKnockout && <QualifiersTable data={data} />}
         </div>
     );
 }

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -128,7 +128,7 @@ export function CupPage() {
                         handleUserChange={handleUserChange}
                     />
                     <GameweekSelector data={data} />
-                    <Link to="/cup/submit" className={styles.submitLink}>
+                    <Link to={`/cup/submit?gameweek=${data.selectedGameweek}`} className={styles.submitLink}>
                         Submit my team
                     </Link>
                 </div>

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -1,0 +1,72 @@
+/* Location: app/cup/cup.page.tsx */
+
+import { Link, useLoaderData } from 'react-router';
+import styles from './cup.module.css';
+import { CUP_STAGES } from './lib/cup-rules';
+import type { CupOverviewRow, CupPageData } from './types/cup-page-types';
+
+function StatusCell({ row }: { row: CupOverviewRow }) {
+    if (row.visibility === 'revealed') {
+        return <span className={styles.revealed}>{row.players?.length ?? 0} players submitted</span>;
+    }
+    if (row.visibility === 'submitted_hidden') {
+        return <span className={styles.hidden}>🔒 Hidden until deadline</span>;
+    }
+    return <span className={styles.pending}>Not submitted</span>;
+}
+
+export function CupPage() {
+    const data = useLoaderData<CupPageData>();
+    const stageLabel = data.round ? CUP_STAGES[data.round.stage].label : null;
+
+    return (
+        <div className={styles.page}>
+            <div className={styles.header}>
+                <div>
+                    <h1 className={styles.title}>Cup</h1>
+                    {stageLabel && (
+                        <span className={styles.roundLabel}>
+                            {stageLabel}
+                            {data.round?.twoLegged ? ` · Leg ${data.round.leg}` : ''} · GW{data.gameweek}
+                        </span>
+                    )}
+                </div>
+                <Link to="/cup/submit" className={styles.submitLink}>
+                    Submit my team
+                </Link>
+            </div>
+
+            {data.hasConfig ? (
+                <table className={styles.table}>
+                    <thead>
+                        <tr>
+                            <th className={styles.headerCell}>Manager</th>
+                            <th className={styles.headerCell}>Division</th>
+                            <th className={styles.headerCell}>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {data.rows.map((row) => (
+                            <tr key={row.manager}>
+                                <td className={styles.cell}>
+                                    <span className={styles.managerName}>{row.userName}</span>
+                                    <span className={styles.teamName}>{row.teamName}</span>
+                                </td>
+                                <td className={styles.cell}>{row.division}</td>
+                                <td className={styles.cell}>
+                                    <StatusCell row={row} />
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            ) : (
+                <p className={styles.notice}>
+                    The cup isn't set up for this gameweek yet. An admin needs to map the cup stages to gameweeks.
+                </p>
+            )}
+        </div>
+    );
+}
+
+export default CupPage;

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -15,6 +15,24 @@ function StatusCell({ row }: { row: CupOverviewRow }) {
     return <span className={styles.pending}>Not submitted</span>;
 }
 
+function Bracket({ data }: { data: CupPageData }) {
+    if (data.bracket.length === 0) return null;
+    return (
+        <section className={styles.qualifiers}>
+            <h2 className={styles.sectionTitle}>Knockout bracket</h2>
+            <ul className={styles.qualifierList}>
+                {data.bracket.map((matchup) => (
+                    <li key={`${matchup.stage}-${matchup.tie}`} className={styles.qualifierItem}>
+                        <span className={styles.qualifierName}>{matchup.home ?? 'TBC'}</span>
+                        <span className={styles.pending}>v</span>
+                        <span className={styles.qualifierName}>{matchup.away ?? 'BYE'}</span>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}
+
 function QualifiersTable({ data }: { data: CupPageData }) {
     if (data.qualifiers.length === 0) return null;
     return (
@@ -83,6 +101,7 @@ export function CupPage() {
                 </p>
             )}
 
+            <Bracket data={data} />
             <QualifiersTable data={data} />
         </div>
     );

--- a/draft/app/cup/cup.page.tsx
+++ b/draft/app/cup/cup.page.tsx
@@ -3,29 +3,10 @@
 import { Link, useLoaderData, useSearchParams } from 'react-router';
 import { SelectUser } from '../_shared/components/select-user';
 import { setUserSelection } from '../_shared/features/user-selection/user-selection.utils';
+import { CupFixtures } from './components/cup-fixtures';
 import styles from './cup.module.css';
 import { CUP_STAGES } from './lib/cup-rules';
 import type { CupOverviewRow, CupPageData } from './types/cup-page-types';
-
-function CupFixtures({ data }: { data: CupPageData }) {
-    if (data.fixtures.length === 0) return null;
-    return (
-        <section className={styles.fixtures}>
-            <h2 className={styles.sectionTitle}>Fixtures · GW{data.selectedGameweek}</h2>
-            <ul className={styles.fixtureList}>
-                {data.fixtures.map((fixture) => (
-                    <li key={`${fixture.home}-${fixture.away}`} className={styles.fixture}>
-                        <span className={styles.fixtureTeam}>{fixture.home}</span>
-                        <span className={styles.fixtureScore}>
-                            {fixture.started ? `${fixture.homeScore}–${fixture.awayScore}` : 'v'}
-                        </span>
-                        <span className={styles.fixtureTeam}>{fixture.away}</span>
-                    </li>
-                ))}
-            </ul>
-        </section>
-    );
-}
 
 function GameweekSelector({ data }: { data: CupPageData }) {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -134,7 +115,7 @@ export function CupPage() {
                 </div>
             </div>
 
-            <CupFixtures data={data} />
+            <CupFixtures fixtures={data.fixtures} gameweek={data.selectedGameweek} />
 
             {data.hasConfig ? (
                 <table className={styles.table}>

--- a/draft/app/cup/cup.route.tsx
+++ b/draft/app/cup/cup.route.tsx
@@ -25,11 +25,17 @@ const EMPTY: CupPageData = {
     standings: [],
     qualifiers: [],
     bracket: [],
+    selectedGameweek: 0,
+    gameweekOptions: [],
 };
 
-export async function loader(_args: LoaderFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
     const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
-    const [currentGameweekData, userTeams] = await Promise.all([fplApiCache.getCurrentGameweekData(), readUserTeams()]);
+    const [currentGameweekData, events, userTeams] = await Promise.all([
+        fplApiCache.getCurrentGameweekData(),
+        fplApiCache.getFplEvents(),
+        readUserTeams(),
+    ]);
 
     // The cup config/sheet may not be set up yet — degrade gracefully rather than 500.
     try {
@@ -39,7 +45,21 @@ export async function loader(_args: LoaderFunctionArgs) {
             readPlayerGameweekPointsFromSheet(),
             readCupBracket().catch(() => []),
         ]);
-        const pageData = getCupPageData({ userTeams, currentGameweekData, cupConfig, submissions, pointsRows });
+
+        // Which gameweek to view: an explicit ?gameweek wins; otherwise the current
+        // gameweek if it's a cup gameweek, else the first configured cup gameweek.
+        const { resolveCupRounds } = await import('./lib/cup-config');
+        const cupGameweeks = resolveCupRounds(cupConfig).map((round) => round.gameweek);
+        const requested = Number.parseInt(new URL(request.url).searchParams.get('gameweek') ?? '', 10);
+        const currentId = currentGameweekData.fplEvent.id;
+        const selectedGameweek = Number.isNaN(requested)
+            ? cupGameweeks.includes(currentId)
+                ? currentId
+                : (cupGameweeks[0] ?? currentId)
+            : requested;
+        const gameweekData = events.find((event) => event.fplEvent.id === selectedGameweek) ?? currentGameweekData;
+
+        const pageData = getCupPageData({ userTeams, gameweekData, cupConfig, submissions, pointsRows });
         return data<CupPageData>({ ...pageData, bracket });
     } catch (error) {
         console.error('Cup loader (config/submissions) error:', error);

--- a/draft/app/cup/cup.route.tsx
+++ b/draft/app/cup/cup.route.tsx
@@ -2,10 +2,12 @@
 
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data } from 'react-router';
+import { getUserSelection } from '../_shared/features/user-selection/user-selection.utils';
 import { readCupBracket, readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
 import { readPlayerGameweekPointsFromSheet } from '../_shared/lib/sheets/player-gw-points';
 import { readUserTeams } from '../_shared/lib/sheets/user-teams';
 import { CupPage } from './cup.page';
+import { buildCupFixtures } from './lib/cup-fixtures';
 import { getCupPageData } from './server/cup.server';
 import type { CupPageData } from './types/cup-page-types';
 
@@ -27,15 +29,21 @@ const EMPTY: CupPageData = {
     bracket: [],
     selectedGameweek: 0,
     gameweekOptions: [],
+    fixtures: [],
+    userTeams: [],
+    selectedUserId: null,
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
-    const [currentGameweekData, events, userTeams] = await Promise.all([
+    const [currentGameweekData, events, userTeams, fixtures, teams] = await Promise.all([
         fplApiCache.getCurrentGameweekData(),
         fplApiCache.getFplEvents(),
         readUserTeams(),
+        fplApiCache.getFplFixtures(),
+        fplApiCache.getFplTeams(),
     ]);
+    const selectedUserId = getUserSelection(request).selectedUserId;
 
     // The cup config/sheet may not be set up yet — degrade gracefully rather than 500.
     try {
@@ -60,10 +68,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
         const gameweekData = events.find((event) => event.fplEvent.id === selectedGameweek) ?? currentGameweekData;
 
         const pageData = getCupPageData({ userTeams, gameweekData, cupConfig, submissions, pointsRows });
-        return data<CupPageData>({ ...pageData, bracket });
+        const cupFixtures = buildCupFixtures(fixtures, teams, selectedGameweek);
+        return data<CupPageData>({ ...pageData, bracket, fixtures: cupFixtures, userTeams, selectedUserId });
     } catch (error) {
         console.error('Cup loader (config/submissions) error:', error);
-        return data<CupPageData>({ ...EMPTY, gameweek: currentGameweekData.fplEvent.id });
+        return data<CupPageData>({ ...EMPTY, gameweek: currentGameweekData.fplEvent.id, userTeams, selectedUserId });
     }
 }
 

--- a/draft/app/cup/cup.route.tsx
+++ b/draft/app/cup/cup.route.tsx
@@ -7,7 +7,9 @@ import { readCupBracket, readCupConfig, readCupSubmissions } from '../_shared/li
 import { readPlayerGameweekPointsFromSheet } from '../_shared/lib/sheets/player-gw-points';
 import { readUserTeams } from '../_shared/lib/sheets/user-teams';
 import { CupPage } from './cup.page';
+import { isDeadlinePassed } from './lib/cup-deadlines';
 import { buildCupFixtures } from './lib/cup-fixtures';
+import { buildStageMatchups } from './lib/cup-matchups';
 import { getCupPageData } from './server/cup.server';
 import type { CupPageData } from './types/cup-page-types';
 
@@ -30,6 +32,7 @@ const EMPTY: CupPageData = {
     selectedGameweek: 0,
     gameweekOptions: [],
     fixtures: [],
+    stageMatchups: [],
     userTeams: [],
     selectedUserId: null,
 };
@@ -69,7 +72,34 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
         const pageData = getCupPageData({ userTeams, gameweekData, cupConfig, submissions, pointsRows });
         const cupFixtures = buildCupFixtures(fixtures, teams, selectedGameweek);
-        return data<CupPageData>({ ...pageData, bracket, fixtures: cupFixtures, userTeams, selectedUserId });
+
+        // For a knockout stage, pair the drawn bracket into head-to-head matchups with scores.
+        const eventsById = new Map(events.map((event) => [event.fplEvent.id, event]));
+        const userNameById = new Map(userTeams.map((team) => [team.userId, team.userName]));
+        const stageMatchups =
+            pageData.round && pageData.round.stage !== 'league'
+                ? buildStageMatchups({
+                      bracket,
+                      round: pageData.round,
+                      cupConfig,
+                      submissions,
+                      pointsRows,
+                      userNameById,
+                      deadlinePassedFor: (gameweek) => {
+                          const event = eventsById.get(gameweek);
+                          return event ? isDeadlinePassed(event) : false;
+                      },
+                  })
+                : [];
+
+        return data<CupPageData>({
+            ...pageData,
+            bracket,
+            fixtures: cupFixtures,
+            stageMatchups,
+            userTeams,
+            selectedUserId,
+        });
     } catch (error) {
         console.error('Cup loader (config/submissions) error:', error);
         return data<CupPageData>({ ...EMPTY, gameweek: currentGameweekData.fplEvent.id, userTeams, selectedUserId });

--- a/draft/app/cup/cup.route.tsx
+++ b/draft/app/cup/cup.route.tsx
@@ -2,7 +2,7 @@
 
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data } from 'react-router';
-import { readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
+import { readCupBracket, readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
 import { readPlayerGameweekPointsFromSheet } from '../_shared/lib/sheets/player-gw-points';
 import { readUserTeams } from '../_shared/lib/sheets/user-teams';
 import { CupPage } from './cup.page';
@@ -24,6 +24,7 @@ const EMPTY: CupPageData = {
     rows: [],
     standings: [],
     qualifiers: [],
+    bracket: [],
 };
 
 export async function loader(_args: LoaderFunctionArgs) {
@@ -32,13 +33,14 @@ export async function loader(_args: LoaderFunctionArgs) {
 
     // The cup config/sheet may not be set up yet — degrade gracefully rather than 500.
     try {
-        const [cupConfig, submissions, pointsRows] = await Promise.all([
+        const [cupConfig, submissions, pointsRows, bracket] = await Promise.all([
             readCupConfig(),
             readCupSubmissions(),
             readPlayerGameweekPointsFromSheet(),
+            readCupBracket().catch(() => []),
         ]);
         const pageData = getCupPageData({ userTeams, currentGameweekData, cupConfig, submissions, pointsRows });
-        return data<CupPageData>(pageData);
+        return data<CupPageData>({ ...pageData, bracket });
     } catch (error) {
         console.error('Cup loader (config/submissions) error:', error);
         return data<CupPageData>({ ...EMPTY, gameweek: currentGameweekData.fplEvent.id });

--- a/draft/app/cup/cup.route.tsx
+++ b/draft/app/cup/cup.route.tsx
@@ -1,0 +1,41 @@
+/* Location: app/cup/cup.route.tsx */
+
+import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { data } from 'react-router';
+import { readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
+import { readUserTeams } from '../_shared/lib/sheets/user-teams';
+import { CupPage } from './cup.page';
+import { getCupPageData } from './server/cup.server';
+import type { CupPageData } from './types/cup-page-types';
+
+export const meta: MetaFunction = () => {
+    return [
+        { title: 'Cup - Fantasy Football Draft' },
+        { name: 'description', content: 'Cup standings and knockout progress' },
+    ];
+};
+
+const EMPTY: CupPageData = {
+    hasConfig: false,
+    round: null,
+    gameweek: 0,
+    deadlinePassed: false,
+    rows: [],
+};
+
+export async function loader(_args: LoaderFunctionArgs) {
+    const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
+    const [currentGameweekData, userTeams] = await Promise.all([fplApiCache.getCurrentGameweekData(), readUserTeams()]);
+
+    // The cup config/sheet may not be set up yet — degrade gracefully rather than 500.
+    try {
+        const [cupConfig, submissions] = await Promise.all([readCupConfig(), readCupSubmissions()]);
+        const pageData = getCupPageData({ userTeams, currentGameweekData, cupConfig, submissions });
+        return data<CupPageData>(pageData);
+    } catch (error) {
+        console.error('Cup loader (config/submissions) error:', error);
+        return data<CupPageData>({ ...EMPTY, gameweek: currentGameweekData.fplEvent.id });
+    }
+}
+
+export default CupPage;

--- a/draft/app/cup/cup.route.tsx
+++ b/draft/app/cup/cup.route.tsx
@@ -3,6 +3,7 @@
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data } from 'react-router';
 import { readCupConfig, readCupSubmissions } from '../_shared/lib/sheets/cup';
+import { readPlayerGameweekPointsFromSheet } from '../_shared/lib/sheets/player-gw-points';
 import { readUserTeams } from '../_shared/lib/sheets/user-teams';
 import { CupPage } from './cup.page';
 import { getCupPageData } from './server/cup.server';
@@ -21,6 +22,8 @@ const EMPTY: CupPageData = {
     gameweek: 0,
     deadlinePassed: false,
     rows: [],
+    standings: [],
+    qualifiers: [],
 };
 
 export async function loader(_args: LoaderFunctionArgs) {
@@ -29,8 +32,12 @@ export async function loader(_args: LoaderFunctionArgs) {
 
     // The cup config/sheet may not be set up yet — degrade gracefully rather than 500.
     try {
-        const [cupConfig, submissions] = await Promise.all([readCupConfig(), readCupSubmissions()]);
-        const pageData = getCupPageData({ userTeams, currentGameweekData, cupConfig, submissions });
+        const [cupConfig, submissions, pointsRows] = await Promise.all([
+            readCupConfig(),
+            readCupSubmissions(),
+            readPlayerGameweekPointsFromSheet(),
+        ]);
+        const pageData = getCupPageData({ userTeams, currentGameweekData, cupConfig, submissions, pointsRows });
         return data<CupPageData>(pageData);
     } catch (error) {
         console.error('Cup loader (config/submissions) error:', error);

--- a/draft/app/cup/lib/autopick.test.ts
+++ b/draft/app/cup/lib/autopick.test.ts
@@ -1,0 +1,25 @@
+/* Location: app/cup/lib/autopick.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { generateAutopick } from './autopick';
+import type { CupSquadPlayer } from './cup-squad';
+
+function player(code: number, name: string): CupSquadPlayer {
+    return { code, name, position: 'mid', isSub: false, isPending: false };
+}
+
+const SQUAD: CupSquadPlayer[] = [player(1, 'Zidane'), player(2, 'Ada'), player(3, 'Charlie'), player(4, 'Beckham')];
+
+describe('generateAutopick', () => {
+    it('picks the required number of players alphabetically', () => {
+        expect(generateAutopick(SQUAD, 2)).toEqual([2, 4]); // Ada, Beckham
+    });
+
+    it('excludes players already used in the other leg', () => {
+        expect(generateAutopick(SQUAD, 2, [2])).toEqual([4, 3]); // skip Ada -> Beckham, Charlie
+    });
+
+    it('returns fewer than required when the squad is too small', () => {
+        expect(generateAutopick(SQUAD, 10)).toHaveLength(4);
+    });
+});

--- a/draft/app/cup/lib/autopick.ts
+++ b/draft/app/cup/lib/autopick.ts
@@ -1,0 +1,22 @@
+/* Location: app/cup/lib/autopick.ts */
+
+import type { CupSquadPlayer } from './cup-squad';
+
+/**
+ * Auto-select a manager's cup team when they miss a deadline: take the required
+ * number of eligible players from their squad, excluding any already used in the
+ * other leg of the round, chosen alphabetically for a deterministic result.
+ * Returns fewer than required only if the squad can't supply enough.
+ */
+export function generateAutopick(
+    squad: CupSquadPlayer[],
+    playersRequired: number,
+    usedPlayers: number[] = [],
+): number[] {
+    const used = new Set(usedPlayers);
+    return squad
+        .filter((player) => !used.has(player.code))
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .slice(0, playersRequired)
+        .map((player) => player.code);
+}

--- a/draft/app/cup/lib/cup-config.test.ts
+++ b/draft/app/cup/lib/cup-config.test.ts
@@ -1,0 +1,69 @@
+/* Location: app/cup/lib/cup-config.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { CupConfig } from '../types/cup-types';
+import {
+    getGameweekForStage,
+    getRoundForGameweek,
+    parseCupConfig,
+    resolveCupRounds,
+    serializeCupConfig,
+} from './cup-config';
+
+const CONFIG: CupConfig = {
+    season: '2526',
+    league: [21, 22, 23],
+    r16: [24, 25],
+    qf: [27, 28],
+    sf: [30, 32],
+    final: 33,
+};
+
+describe('resolveCupRounds', () => {
+    it('flattens the config into one round per gameweek played', () => {
+        const rounds = resolveCupRounds(CONFIG);
+        // 3 league + 2 + 2 + 2 knockout legs + 1 final = 10
+        expect(rounds).toHaveLength(10);
+        expect(rounds.map((r) => r.gameweek)).toEqual([21, 22, 23, 24, 25, 27, 28, 30, 32, 33]);
+    });
+
+    it('carries the correct players-required and leg numbers per stage', () => {
+        const rounds = resolveCupRounds(CONFIG);
+        const final = rounds.find((r) => r.stage === 'final');
+        expect(final).toMatchObject({ gameweek: 33, leg: 1, playersRequired: 6, twoLegged: false });
+
+        const r16Leg2 = rounds.find((r) => r.stage === 'r16' && r.leg === 2);
+        expect(r16Leg2).toMatchObject({ gameweek: 25, playersRequired: 4, twoLegged: true });
+    });
+});
+
+describe('gameweek <-> stage lookups', () => {
+    it('finds the round played in a gameweek', () => {
+        expect(getRoundForGameweek(CONFIG, 27)).toMatchObject({ stage: 'qf', leg: 1 });
+        expect(getRoundForGameweek(CONFIG, 99)).toBeNull();
+    });
+
+    it('finds the gameweek for a stage/leg', () => {
+        expect(getGameweekForStage(CONFIG, 'sf', 2)).toBe(32);
+        expect(getGameweekForStage(CONFIG, 'final')).toBe(33);
+        expect(getGameweekForStage(CONFIG, 'qf', 3)).toBeNull();
+    });
+});
+
+describe('parse/serialize config rows (sheet round-trip)', () => {
+    it('parses key/value rows into a typed config', () => {
+        const parsed = parseCupConfig([
+            { key: 'season', value: '2526' },
+            { key: 'league', value: '21, 22, 23' },
+            { key: 'r16', value: '24,25' },
+            { key: 'qf', value: '27,28' },
+            { key: 'sf', value: '30,32' },
+            { key: 'final', value: '33' },
+        ]);
+        expect(parsed).toEqual(CONFIG);
+    });
+
+    it('round-trips through serialize -> parse unchanged', () => {
+        expect(parseCupConfig(serializeCupConfig(CONFIG))).toEqual(CONFIG);
+    });
+});

--- a/draft/app/cup/lib/cup-config.ts
+++ b/draft/app/cup/lib/cup-config.ts
@@ -1,0 +1,111 @@
+/* Location: app/cup/lib/cup-config.ts */
+
+import type { CupConfig, CupRound, CupStageId } from '../types/cup-types';
+import { CUP_STAGES } from './cup-rules';
+
+const TWO_LEGGED_STAGES = ['r16', 'qf', 'sf'] as const;
+
+/**
+ * Expand an admin CupConfig into the ordered list of concrete rounds, one per
+ * gameweek played. This is the bridge between "which gameweek is which stage"
+ * (config) and everything that keys off a single gameweek.
+ */
+export function resolveCupRounds(config: CupConfig): CupRound[] {
+    const rounds: CupRound[] = [];
+
+    for (const gameweek of config.league) {
+        rounds.push({
+            stage: 'league',
+            leg: 1,
+            gameweek,
+            playersRequired: CUP_STAGES.league.playersRequired,
+            twoLegged: false,
+        });
+    }
+
+    for (const stage of TWO_LEGGED_STAGES) {
+        const [leg1, leg2] = config[stage];
+        rounds.push({
+            stage,
+            leg: 1,
+            gameweek: leg1,
+            playersRequired: CUP_STAGES[stage].playersRequired,
+            twoLegged: true,
+        });
+        rounds.push({
+            stage,
+            leg: 2,
+            gameweek: leg2,
+            playersRequired: CUP_STAGES[stage].playersRequired,
+            twoLegged: true,
+        });
+    }
+
+    rounds.push({
+        stage: 'final',
+        leg: 1,
+        gameweek: config.final,
+        playersRequired: CUP_STAGES.final.playersRequired,
+        twoLegged: false,
+    });
+
+    return rounds;
+}
+
+/** The round (stage + leg) played in a given gameweek, if any. */
+export function getRoundForGameweek(config: CupConfig, gameweek: number): CupRound | null {
+    return resolveCupRounds(config).find((round) => round.gameweek === gameweek) ?? null;
+}
+
+/** The gameweek a given stage/leg is played in, if configured. */
+export function getGameweekForStage(config: CupConfig, stage: CupStageId, leg = 1): number | null {
+    const round = resolveCupRounds(config).find((r) => r.stage === stage && r.leg === leg);
+    return round ? round.gameweek : null;
+}
+
+/**
+ * Config is stored in the sheet as simple key/value rows so an admin can edit
+ * it by hand if needed. These pure helpers convert between that flat form and
+ * the typed CupConfig, and are unit-tested independently of the sheet client.
+ */
+export interface CupConfigRow {
+    key: string;
+    value: string;
+}
+
+function parseGameweekList(value: string): number[] {
+    return value
+        .split(',')
+        .map((part) => Number.parseInt(part.trim(), 10))
+        .filter((n) => !Number.isNaN(n));
+}
+
+function parseLeggedPair(value: string): [number, number] {
+    const gameweeks = parseGameweekList(value);
+    return [gameweeks[0] ?? Number.NaN, gameweeks[1] ?? Number.NaN];
+}
+
+export function parseCupConfig(rows: CupConfigRow[]): CupConfig {
+    const byKey = new Map(rows.map((row) => [row.key.trim().toLowerCase(), row.value]));
+    const get = (key: string): string => byKey.get(key) ?? '';
+
+    return {
+        season: get('season'),
+        league: parseGameweekList(get('league')),
+        r16: parseLeggedPair(get('r16')),
+        qf: parseLeggedPair(get('qf')),
+        sf: parseLeggedPair(get('sf')),
+        final: Number.parseInt(get('final').trim(), 10),
+    };
+}
+
+export function serializeCupConfig(config: CupConfig): CupConfigRow[] {
+    return [
+        { key: 'season', value: config.season },
+        { key: 'league', value: config.league.join(',') },
+        { key: 'r16', value: config.r16.join(',') },
+        { key: 'qf', value: config.qf.join(',') },
+        { key: 'sf', value: config.sf.join(',') },
+        { key: 'final', value: String(config.final) },
+    ];
+}

--- a/draft/app/cup/lib/cup-deadlines.test.ts
+++ b/draft/app/cup/lib/cup-deadlines.test.ts
@@ -1,0 +1,48 @@
+/* Location: app/cup/lib/cup-deadlines.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
+import { isAggregateRevealed, isDeadlinePassed, isSubmissionOpen, isTeamRevealed } from './cup-deadlines';
+
+function makeGameweek(startIso: string, endIso: string): GameWeekData {
+    return {
+        fplEvent: { deadline_time: endIso, finished: false, id: 24, is_current: true, is_next: false, name: 'GW24' },
+        gameWeekIndex: 23,
+        start: new Date(startIso),
+        end: new Date(endIso),
+        isCurrent: true,
+        isNext: false,
+        hasPassed: false,
+    };
+}
+
+const GW = makeGameweek('2026-01-24T11:00:00Z', '2026-01-31T13:30:00Z');
+
+describe('deadline + submission window', () => {
+    it('locks once the deadline has passed', () => {
+        expect(isDeadlinePassed(GW, new Date('2026-01-31T13:29:00Z'))).toBe(false);
+        expect(isDeadlinePassed(GW, new Date('2026-01-31T13:30:00Z'))).toBe(true);
+        expect(isDeadlinePassed(GW, new Date('2026-02-01T00:00:00Z'))).toBe(true);
+    });
+
+    it('is open only between the previous deadline and this one', () => {
+        expect(isSubmissionOpen(GW, new Date('2026-01-24T10:59:00Z'))).toBe(false); // before window
+        expect(isSubmissionOpen(GW, new Date('2026-01-28T12:00:00Z'))).toBe(true); // in window
+        expect(isSubmissionOpen(GW, new Date('2026-01-31T13:30:00Z'))).toBe(false); // at deadline
+    });
+});
+
+describe('reveal gating', () => {
+    it('reveals a team only when the deadline has passed AND subs are confirmed', () => {
+        expect(isTeamRevealed({ deadlinePassed: false, subsConfirmed: false })).toBe(false);
+        expect(isTeamRevealed({ deadlinePassed: true, subsConfirmed: false })).toBe(false); // past deadline, unconfirmed
+        expect(isTeamRevealed({ deadlinePassed: false, subsConfirmed: true })).toBe(false);
+        expect(isTeamRevealed({ deadlinePassed: true, subsConfirmed: true })).toBe(true);
+    });
+
+    it('reveals the aggregate only when every leg is revealed', () => {
+        expect(isAggregateRevealed([true, false])).toBe(false);
+        expect(isAggregateRevealed([true, true])).toBe(true);
+        expect(isAggregateRevealed([])).toBe(false);
+    });
+});

--- a/draft/app/cup/lib/cup-deadlines.ts
+++ b/draft/app/cup/lib/cup-deadlines.ts
@@ -1,0 +1,36 @@
+/* Location: app/cup/lib/cup-deadlines.ts */
+
+import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
+
+/**
+ * Deadline + visibility rules for the cup. Deadlines come from the configured
+ * gameweek's FPL deadline (GameWeekData.end), matching the rest of the site —
+ * no cup-specific deadline data exists.
+ */
+
+/** The gameweek deadline has passed; submissions are locked. */
+export function isDeadlinePassed(gameweek: GameWeekData, now: Date = new Date()): boolean {
+    return now.getTime() >= new Date(gameweek.end).getTime();
+}
+
+/** Submissions are open between the previous deadline and this gameweek's deadline. */
+export function isSubmissionOpen(gameweek: GameWeekData, now: Date = new Date()): boolean {
+    const start = new Date(gameweek.start).getTime();
+    const end = new Date(gameweek.end).getTime();
+    const current = now.getTime();
+    return current >= start && current < end;
+}
+
+/**
+ * A manager's team is revealed publicly only once BOTH the deadline has passed
+ * AND their substitutions are confirmed. Confirmation gates reveal because a
+ * pending sub could still change the team, so showing it early would be wrong.
+ */
+export function isTeamRevealed(params: { deadlinePassed: boolean; subsConfirmed: boolean }): boolean {
+    return params.deadlinePassed && params.subsConfirmed;
+}
+
+/** The two-legged aggregate is only shown once both legs are individually revealed. */
+export function isAggregateRevealed(legRevealed: boolean[]): boolean {
+    return legRevealed.length > 0 && legRevealed.every(Boolean);
+}

--- a/draft/app/cup/lib/cup-fixtures.test.ts
+++ b/draft/app/cup/lib/cup-fixtures.test.ts
@@ -1,0 +1,58 @@
+/* Location: app/cup/lib/cup-fixtures.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { FplFixtureData, FplTeam } from '../../_shared/lib/fpl/fpl-types';
+import { buildCupFixtures } from './cup-fixtures';
+
+const TEAMS = [
+    { id: 1, short_name: 'ARS' },
+    { id: 2, short_name: 'CHE' },
+    { id: 3, short_name: 'LIV' },
+] as unknown as FplTeam[];
+
+const FIXTURES = [
+    {
+        event: 24,
+        team_h: 1,
+        team_a: 2,
+        kickoff_time: 'T1',
+        started: true,
+        finished: true,
+        team_h_score: 2,
+        team_a_score: 1,
+    },
+    {
+        event: 24,
+        team_h: 3,
+        team_a: 1,
+        kickoff_time: 'T2',
+        started: false,
+        finished: false,
+        team_h_score: 0,
+        team_a_score: 0,
+    },
+    {
+        event: 25,
+        team_h: 2,
+        team_a: 3,
+        kickoff_time: 'T3',
+        started: false,
+        finished: false,
+        team_h_score: 0,
+        team_a_score: 0,
+    },
+] as unknown as FplFixtureData[];
+
+describe('buildCupFixtures', () => {
+    it('returns only the requested gameweek, with team names resolved', () => {
+        const result = buildCupFixtures(FIXTURES, TEAMS, 24);
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({ home: 'ARS', away: 'CHE' });
+    });
+
+    it('shows scores only once a fixture has started', () => {
+        const [played, upcoming] = buildCupFixtures(FIXTURES, TEAMS, 24);
+        expect(played).toMatchObject({ homeScore: 2, awayScore: 1, finished: true });
+        expect(upcoming).toMatchObject({ homeScore: null, awayScore: null, started: false });
+    });
+});

--- a/draft/app/cup/lib/cup-fixtures.ts
+++ b/draft/app/cup/lib/cup-fixtures.ts
@@ -1,0 +1,30 @@
+/* Location: app/cup/lib/cup-fixtures.ts */
+
+import type { FplFixtureData, FplTeam } from '../../_shared/lib/fpl/fpl-types';
+
+/** A single real-world fixture shown at the top of the cup page for a gameweek. */
+export interface CupFixture {
+    home: string;
+    away: string;
+    kickoff: string;
+    started: boolean;
+    finished: boolean;
+    homeScore: number | null;
+    awayScore: number | null;
+}
+
+/** The fixtures for one gameweek, with team ids resolved to short names. */
+export function buildCupFixtures(fixtures: FplFixtureData[], teams: FplTeam[], gameweek: number): CupFixture[] {
+    const nameById = new Map(teams.map((team) => [team.id, team.short_name]));
+    return fixtures
+        .filter((fixture) => fixture.event === gameweek)
+        .map((fixture) => ({
+            home: nameById.get(fixture.team_h) ?? String(fixture.team_h),
+            away: nameById.get(fixture.team_a) ?? String(fixture.team_a),
+            kickoff: fixture.kickoff_time,
+            started: fixture.started,
+            finished: fixture.finished,
+            homeScore: fixture.started ? fixture.team_h_score : null,
+            awayScore: fixture.started ? fixture.team_a_score : null,
+        }));
+}

--- a/draft/app/cup/lib/cup-matchups.test.ts
+++ b/draft/app/cup/lib/cup-matchups.test.ts
@@ -1,0 +1,93 @@
+/* Location: app/cup/lib/cup-matchups.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { CupConfig, CupMatchup, CupRound, ProcessedCupSheetData } from '../types/cup-types';
+import { buildStageMatchups } from './cup-matchups';
+import type { PlayerPointsRow } from './cup-scoring';
+
+const CONFIG: CupConfig = {
+    season: '2526',
+    league: [21, 22, 23],
+    r16: [24, 25],
+    qf: [27, 28],
+    sf: [30, 32],
+    final: 33,
+};
+
+const POINTS: PlayerPointsRow[] = [
+    { playerCode: 1, 'gw-24': 5, 'gw-25': 4 },
+    { playerCode: 2, 'gw-24': 3, 'gw-25': 6 },
+];
+
+function sub(manager: string, gameweek: number, players: number[], status = 'Y'): ProcessedCupSheetData {
+    return {
+        status,
+        timestamp: new Date('2026-01-01'),
+        manager,
+        division: 'championship',
+        gameweek,
+        stage: 'r16',
+        leg: gameweek === 24 ? 1 : 2,
+        players,
+        submittedByAdmin: false,
+        adminReason: '',
+    };
+}
+
+const BRACKET: CupMatchup[] = [{ stage: 'r16', tie: 0, home: 'a', away: 'b' }];
+const R16_LEG2: CupRound = { stage: 'r16', leg: 2, gameweek: 25, playersRequired: 4, twoLegged: true };
+
+describe('buildStageMatchups', () => {
+    const base = {
+        bracket: BRACKET,
+        round: R16_LEG2,
+        cupConfig: CONFIG,
+        pointsRows: POINTS,
+        userNameById: new Map([
+            ['a', 'Alice'],
+            ['b', 'Bob'],
+        ]),
+    };
+
+    it('pairs the two managers and names them', () => {
+        const [tie] = buildStageMatchups({
+            ...base,
+            submissions: [],
+            deadlinePassedFor: () => false,
+        });
+        expect(tie?.home.name).toBe('Alice');
+        expect(tie?.away.name).toBe('Bob');
+    });
+
+    it('shows leg points and aggregate only when both legs are revealed', () => {
+        const submissions = [sub('a', 24, [1]), sub('a', 25, [1, 2])];
+        const [tie] = buildStageMatchups({
+            ...base,
+            submissions,
+            deadlinePassedFor: () => true, // both legs past deadline + confirmed
+        });
+        expect(tie?.home.points).toBe(10); // gw25 (viewed leg): player1(4) + player2(6)
+        expect(tie?.home.aggregate).toBe(15); // gw24 (5) + gw25 (10)
+    });
+
+    it('hides points until the leg is revealed', () => {
+        const submissions = [sub('a', 25, [1, 2])];
+        const [tie] = buildStageMatchups({
+            ...base,
+            submissions,
+            deadlinePassedFor: () => false, // deadline not passed
+        });
+        expect(tie?.home.points).toBeNull();
+        expect(tie?.home.aggregate).toBeNull();
+    });
+
+    it('labels a missing opponent as a BYE', () => {
+        const [tie] = buildStageMatchups({
+            ...base,
+            bracket: [{ stage: 'r16', tie: 0, home: 'a', away: null }],
+            submissions: [],
+            deadlinePassedFor: () => false,
+        });
+        expect(tie?.away.name).toBe('BYE');
+    });
+});

--- a/draft/app/cup/lib/cup-matchups.ts
+++ b/draft/app/cup/lib/cup-matchups.ts
@@ -43,13 +43,20 @@ export function buildStageMatchups(input: {
         ? [getGameweekForStage(cupConfig, round.stage, 1), getGameweekForStage(cupConfig, round.stage, 2)]
         : [getGameweekForStage(cupConfig, round.stage, 1)];
 
+    // One points map per leg gameweek, built once rather than per submission lookup.
+    const pointsMaps = new Map(
+        legGameweeks
+            .filter((gameweek): gameweek is number => gameweek !== null)
+            .map((gameweek) => [gameweek, buildGameweekPointsMap(pointsRows, gameweek)]),
+    );
+
     const pointsFor = (manager: ManagerId | null, gameweek: number | null): number | null => {
         if (!manager || gameweek === null) return null;
         const submission = submissions.find((s) => s.manager === manager && s.gameweek === gameweek);
         if (!submission) return null;
         const revealed = deadlinePassedFor(gameweek) && submission.status === 'Y';
         if (!revealed) return null;
-        return scoreSubmission(submission.players, buildGameweekPointsMap(pointsRows, gameweek));
+        return scoreSubmission(submission.players, pointsMaps.get(gameweek) ?? new Map());
     };
 
     const aggregateFor = (manager: ManagerId | null): number | null => {

--- a/draft/app/cup/lib/cup-matchups.ts
+++ b/draft/app/cup/lib/cup-matchups.ts
@@ -1,0 +1,77 @@
+/* Location: app/cup/lib/cup-matchups.ts */
+
+import type { ManagerId } from '../../teams/types/team-types';
+import type { CupConfig, CupMatchup, CupRound, ProcessedCupSheetData } from '../types/cup-types';
+import { getGameweekForStage } from './cup-config';
+import { buildGameweekPointsMap, type PlayerPointsRow, scoreSubmission } from './cup-scoring';
+
+export interface CupMatchupSide {
+    manager: ManagerId | null;
+    name: string;
+    /** Points for the leg being viewed (null when hidden or no submission). */
+    points: number | null;
+    /** Aggregate across both legs of a two-legged tie (null when hidden or single-leg). */
+    aggregate: number | null;
+}
+
+export interface CupMatchupView {
+    tie: number;
+    home: CupMatchupSide;
+    away: CupMatchupSide;
+    winner: ManagerId | null;
+}
+
+/**
+ * Build the head-to-head matchups for a knockout stage: pair each tie's two
+ * managers with their points for the viewed leg and, for two-legged rounds,
+ * their aggregate across both legs. A side's score is only shown once that
+ * leg's deadline has passed AND the manager's subs are confirmed — same reveal
+ * rule as the overview.
+ */
+export function buildStageMatchups(input: {
+    bracket: CupMatchup[];
+    round: CupRound;
+    cupConfig: CupConfig;
+    submissions: ProcessedCupSheetData[];
+    pointsRows: PlayerPointsRow[];
+    userNameById: Map<ManagerId, string>;
+    deadlinePassedFor: (gameweek: number) => boolean;
+}): CupMatchupView[] {
+    const { bracket, round, cupConfig, submissions, pointsRows, userNameById, deadlinePassedFor } = input;
+
+    const legGameweeks = round.twoLegged
+        ? [getGameweekForStage(cupConfig, round.stage, 1), getGameweekForStage(cupConfig, round.stage, 2)]
+        : [getGameweekForStage(cupConfig, round.stage, 1)];
+
+    const pointsFor = (manager: ManagerId | null, gameweek: number | null): number | null => {
+        if (!manager || gameweek === null) return null;
+        const submission = submissions.find((s) => s.manager === manager && s.gameweek === gameweek);
+        if (!submission) return null;
+        const revealed = deadlinePassedFor(gameweek) && submission.status === 'Y';
+        if (!revealed) return null;
+        return scoreSubmission(submission.players, buildGameweekPointsMap(pointsRows, gameweek));
+    };
+
+    const aggregateFor = (manager: ManagerId | null): number | null => {
+        if (!manager || !round.twoLegged) return null;
+        const legScores = legGameweeks.map((gameweek) => pointsFor(manager, gameweek));
+        if (legScores.some((score) => score === null)) return null; // both legs must be revealed
+        return legScores.reduce<number>((total, score) => total + (score ?? 0), 0);
+    };
+
+    const side = (manager: ManagerId | null): CupMatchupSide => ({
+        manager,
+        name: manager ? (userNameById.get(manager) ?? manager) : 'BYE',
+        points: pointsFor(manager, round.gameweek),
+        aggregate: aggregateFor(manager),
+    });
+
+    return bracket
+        .filter((matchup) => matchup.stage === round.stage)
+        .map((matchup) => ({
+            tie: matchup.tie,
+            home: side(matchup.home),
+            away: side(matchup.away),
+            winner: matchup.winner ?? null,
+        }));
+}

--- a/draft/app/cup/lib/cup-rules.test.ts
+++ b/draft/app/cup/lib/cup-rules.test.ts
@@ -1,0 +1,69 @@
+/* Location: app/cup/lib/cup-rules.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import {
+    CUP_STAGES,
+    findReusedPlayers,
+    getStageShape,
+    hasReusedPlayer,
+    isDisqualified,
+    isKnockoutStage,
+    MAX_AUTOPICKS_BEFORE_DQ,
+    QUALIFYING_PLACES,
+} from './cup-rules';
+
+describe('cup stage shapes', () => {
+    it('requires 4 players in every stage except the 6-player final', () => {
+        expect(getStageShape('league').playersRequired).toBe(4);
+        expect(getStageShape('r16').playersRequired).toBe(4);
+        expect(getStageShape('qf').playersRequired).toBe(4);
+        expect(getStageShape('sf').playersRequired).toBe(4);
+        expect(getStageShape('final').playersRequired).toBe(6);
+    });
+
+    it('marks only the middle rounds as two-legged', () => {
+        expect(CUP_STAGES.league.twoLegged).toBe(false);
+        expect(CUP_STAGES.r16.twoLegged).toBe(true);
+        expect(CUP_STAGES.qf.twoLegged).toBe(true);
+        expect(CUP_STAGES.sf.twoLegged).toBe(true);
+        expect(CUP_STAGES.final.twoLegged).toBe(false);
+    });
+
+    it('treats r16/qf/sf/final as knockout and the league stage as not', () => {
+        expect(isKnockoutStage('league')).toBe(false);
+        expect(isKnockoutStage('r16')).toBe(true);
+        expect(isKnockoutStage('final')).toBe(true);
+    });
+
+    it('qualifies 16 managers from the league stage', () => {
+        expect(QUALIFYING_PLACES).toBe(16);
+    });
+});
+
+describe('player-reuse ban within a round', () => {
+    it('reports players reused from the other leg', () => {
+        expect(findReusedPlayers([1, 2, 3, 4], [3, 9])).toEqual([3]);
+        expect(hasReusedPlayer([1, 2, 3, 4], [3, 9])).toBe(true);
+    });
+
+    it('allows a completely fresh selection', () => {
+        expect(findReusedPlayers([1, 2, 3, 4], [5, 6, 7, 8])).toEqual([]);
+        expect(hasReusedPlayer([1, 2, 3, 4], [5, 6, 7, 8])).toBe(false);
+    });
+
+    it('treats an empty other leg as no reuse', () => {
+        expect(hasReusedPlayer([1, 2, 3, 4], [])).toBe(false);
+    });
+});
+
+describe('disqualification', () => {
+    it('disqualifies at the autopick limit', () => {
+        expect(isDisqualified(MAX_AUTOPICKS_BEFORE_DQ)).toBe(true);
+        expect(isDisqualified(MAX_AUTOPICKS_BEFORE_DQ + 1)).toBe(true);
+    });
+
+    it('does not disqualify below the limit', () => {
+        expect(isDisqualified(0)).toBe(false);
+        expect(isDisqualified(1)).toBe(false);
+    });
+});

--- a/draft/app/cup/lib/cup-rules.ts
+++ b/draft/app/cup/lib/cup-rules.ts
@@ -1,0 +1,51 @@
+/* Location: app/cup/lib/cup-rules.ts */
+
+import type { CupStageId, CupStageShape } from '../types/cup-types';
+
+/**
+ * Fixed stage shapes. League + final are single-leg; the middle rounds are
+ * two-legged. Player counts follow the cup rules: 4 per team everywhere except
+ * the 6-player Grand Final.
+ */
+export const CUP_STAGES: Record<CupStageId, CupStageShape> = {
+    league: { id: 'league', label: 'League Stage', playersRequired: 4, twoLegged: false },
+    r16: { id: 'r16', label: 'Round of 16', playersRequired: 4, twoLegged: true },
+    qf: { id: 'qf', label: 'Quarter Final', playersRequired: 4, twoLegged: true },
+    sf: { id: 'sf', label: 'Semi Final', playersRequired: 4, twoLegged: true },
+    final: { id: 'final', label: 'Grand Final', playersRequired: 6, twoLegged: false },
+};
+
+/** Knockout stages, in bracket order. */
+export const KNOCKOUT_STAGES: CupStageId[] = ['r16', 'qf', 'sf', 'final'];
+
+/** Managers that qualify from the league stage into the Round of 16. */
+export const QUALIFYING_PLACES = 16;
+
+/** Reaching this many autopicks in a single stage disqualifies a manager. */
+export const MAX_AUTOPICKS_BEFORE_DQ = 2;
+
+export function getStageShape(stage: CupStageId): CupStageShape {
+    return CUP_STAGES[stage];
+}
+
+export function isKnockoutStage(stage: CupStageId): boolean {
+    return KNOCKOUT_STAGES.includes(stage);
+}
+
+/**
+ * Player-reuse ban: a player used in one leg of a round cannot be reused in
+ * the other leg of the same round. Returns the overlapping player codes.
+ */
+export function findReusedPlayers(currentPlayers: number[], usedPlayers: number[]): number[] {
+    const used = new Set(usedPlayers);
+    return currentPlayers.filter((code) => used.has(code));
+}
+
+export function hasReusedPlayer(currentPlayers: number[], usedPlayers: number[]): boolean {
+    return findReusedPlayers(currentPlayers, usedPlayers).length > 0;
+}
+
+/** A manager is disqualified once they hit the autopick limit within a stage. */
+export function isDisqualified(autopickCount: number): boolean {
+    return autopickCount >= MAX_AUTOPICKS_BEFORE_DQ;
+}

--- a/draft/app/cup/lib/cup-scoring.test.ts
+++ b/draft/app/cup/lib/cup-scoring.test.ts
@@ -1,0 +1,35 @@
+/* Location: app/cup/lib/cup-scoring.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { buildGameweekPointsMap, type PlayerPointsRow, scoreSubmission } from './cup-scoring';
+
+const ROWS: PlayerPointsRow[] = [
+    { playerCode: 10, 'gw-24': 6, 'gw-25': 2 },
+    { playerCode: 11, 'gw-24': '4', 'gw-24-b': '3' }, // double gameweek, string values
+    { playerCode: 12, 'gw-25': 9 },
+];
+
+describe('buildGameweekPointsMap', () => {
+    it('reads a gameweek column into a code->points map', () => {
+        const map = buildGameweekPointsMap(ROWS, 24);
+        expect(map.get(10)).toBe(6);
+        expect(map.get(12)).toBe(0); // no gw-24 value
+    });
+
+    it('sums the double-gameweek second value', () => {
+        const map = buildGameweekPointsMap(ROWS, 24);
+        expect(map.get(11)).toBe(7); // 4 + 3
+    });
+});
+
+describe('scoreSubmission', () => {
+    it('sums the selected players league points', () => {
+        const map = buildGameweekPointsMap(ROWS, 24);
+        expect(scoreSubmission([10, 11], map)).toBe(13); // 6 + 7
+    });
+
+    it('treats missing players as zero', () => {
+        const map = buildGameweekPointsMap(ROWS, 24);
+        expect(scoreSubmission([10, 999], map)).toBe(6);
+    });
+});

--- a/draft/app/cup/lib/cup-scoring.test.ts
+++ b/draft/app/cup/lib/cup-scoring.test.ts
@@ -28,6 +28,13 @@ describe('scoreSubmission', () => {
         expect(scoreSubmission([10, 11], map)).toBe(13); // 6 + 7
     });
 
+    it('matches numeric submission codes even when the sheet returns string playerCodes', () => {
+        // The sheet delivers playerCode as a string; submission codes are numbers.
+        const stringRows = [{ playerCode: '10' as unknown as number, 'gw-24': 6 }];
+        const map = buildGameweekPointsMap(stringRows, 24);
+        expect(scoreSubmission([10], map)).toBe(6);
+    });
+
     it('treats missing players as zero', () => {
         const map = buildGameweekPointsMap(ROWS, 24);
         expect(scoreSubmission([10, 999], map)).toBe(6);

--- a/draft/app/cup/lib/cup-scoring.ts
+++ b/draft/app/cup/lib/cup-scoring.ts
@@ -29,7 +29,9 @@ export function buildGameweekPointsMap(rows: PlayerPointsRow[], gameweek: number
     const second = `gw-${gameweek}-b`;
     const map = new Map<number, number>();
     for (const row of rows) {
-        map.set(row.playerCode, toNumber(row[base]) + toNumber(row[second]));
+        // playerCode may arrive as a string from the sheet; submission codes are
+        // numbers, so key the map by Number to keep lookups matching.
+        map.set(Number(row.playerCode), toNumber(row[base]) + toNumber(row[second]));
     }
     return map;
 }

--- a/draft/app/cup/lib/cup-scoring.ts
+++ b/draft/app/cup/lib/cup-scoring.ts
@@ -1,0 +1,40 @@
+/* Location: app/cup/lib/cup-scoring.ts */
+
+/**
+ * Cup scoring reuses the site's existing per-player league points (the
+ * `player-gw-points` sheet, columns `gw-1`, `gw-2`, …). We never recompute
+ * points here, so there is a single source of truth and no double counting.
+ */
+
+export interface PlayerPointsRow {
+    playerCode: number;
+    [key: string]: string | number;
+}
+
+function toNumber(value: string | number | undefined): number {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value);
+        return Number.isNaN(parsed) ? 0 : parsed;
+    }
+    return 0;
+}
+
+/**
+ * Build a code -> points map for a single gameweek. Double gameweeks store a
+ * second value under `gw-N-b`, so both are summed.
+ */
+export function buildGameweekPointsMap(rows: PlayerPointsRow[], gameweek: number): Map<number, number> {
+    const base = `gw-${gameweek}`;
+    const second = `gw-${gameweek}-b`;
+    const map = new Map<number, number>();
+    for (const row of rows) {
+        map.set(row.playerCode, toNumber(row[base]) + toNumber(row[second]));
+    }
+    return map;
+}
+
+/** Total points for a submission = sum of its players' league points that gameweek. */
+export function scoreSubmission(players: number[], pointsByCode: Map<number, number>): number {
+    return players.reduce((total, code) => total + (pointsByCode.get(code) ?? 0), 0);
+}

--- a/draft/app/cup/lib/cup-squad.test.ts
+++ b/draft/app/cup/lib/cup-squad.test.ts
@@ -1,0 +1,26 @@
+/* Location: app/cup/lib/cup-squad.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { makeStandardRoster } from '../../transfers/lib/validators/fixtures';
+import { getCupSquad } from './cup-squad';
+
+describe('getCupSquad', () => {
+    it('returns the 12 selectable squad players and excludes the on-loan slot', () => {
+        const squad = getCupSquad(makeStandardRoster());
+        expect(squad).toHaveLength(12);
+        // on_loan_0 placeholder (code 0) is never selectable
+        expect(squad.map((p) => p.code)).not.toContain(0);
+    });
+
+    it('flags the bench player as a sub', () => {
+        const squad = getCupSquad(makeStandardRoster());
+        const sub = squad.find((p) => p.code === 112);
+        expect(sub?.isSub).toBe(true);
+    });
+
+    it('marks players that are only in the squad via a pending sub', () => {
+        const squad = getCupSquad(makeStandardRoster(), new Set([106]));
+        expect(squad.find((p) => p.code === 106)?.isPending).toBe(true);
+        expect(squad.find((p) => p.code === 107)?.isPending).toBe(false);
+    });
+});

--- a/draft/app/cup/lib/cup-squad.ts
+++ b/draft/app/cup/lib/cup-squad.ts
@@ -1,0 +1,59 @@
+/* Location: app/cup/lib/cup-squad.ts */
+
+import type { CustomPosition } from '../../players/types/player-types';
+import type { PositionSlotKey, TeamRoster } from '../../teams/types/team-types';
+
+/** A player a manager can pick for their cup team, drawn from their squad. */
+export interface CupSquadPlayer {
+    code: number;
+    name: string;
+    position: CustomPosition;
+    isSub: boolean;
+    /** True when this player is only in the squad via an as-yet-unconfirmed (pending) sub. */
+    isPending: boolean;
+}
+
+// Slots that hold a squad player. A player loaned OUT sits in `on_loan_0` and is
+// not available to the lending manager, so it is intentionally excluded.
+const SELECTABLE_SLOTS: PositionSlotKey[] = [
+    'gk_0',
+    'cb_0',
+    'cb_1',
+    'fb_0',
+    'fb_1',
+    'mid_0',
+    'mid_1',
+    'wa_0',
+    'wa_1',
+    'ca_0',
+    'ca_1',
+    'sub_0',
+];
+
+/**
+ * Build the list of players a manager can pick from, based on their roster.
+ * `pendingPlayerCodes` are players who are only present via a pending sub — they
+ * are shown (so the manager sees their likely team) but flagged as pending so the
+ * UI can signal that the pick may still change.
+ */
+export function getCupSquad(roster: TeamRoster, pendingPlayerCodes: Set<number> = new Set()): CupSquadPlayer[] {
+    const squad: CupSquadPlayer[] = [];
+
+    for (const slotKey of SELECTABLE_SLOTS) {
+        const slot = roster[slotKey];
+        if (!slot?.player) continue;
+
+        // A player currently loaned out to another manager is not selectable.
+        if (slot.player.onLoanTo) continue;
+
+        squad.push({
+            code: slot.player.playerCode,
+            name: slot.player.playerName,
+            position: slot.player.playerPosition,
+            isSub: slot.player.isSub,
+            isPending: pendingPlayerCodes.has(slot.player.playerCode),
+        });
+    }
+
+    return squad;
+}

--- a/draft/app/cup/lib/cup-standings.test.ts
+++ b/draft/app/cup/lib/cup-standings.test.ts
@@ -1,0 +1,51 @@
+/* Location: app/cup/lib/cup-standings.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { computeLeagueStandings, getQualifiers, type ScoredSubmission } from './cup-standings';
+
+const LEAGUE_GWS = [21, 22, 23];
+
+function scored(manager: string, gameweek: number, points: number, isAutopick = false): ScoredSubmission {
+    return { manager, gameweek, points, isAutopick };
+}
+
+describe('computeLeagueStandings', () => {
+    it('sums points per manager across the league gameweeks only', () => {
+        const standings = computeLeagueStandings(
+            [scored('a', 21, 10), scored('a', 22, 5), scored('a', 99, 100), scored('b', 21, 8)],
+            LEAGUE_GWS,
+        );
+        const a = standings.find((s) => s.manager === 'a');
+        expect(a?.points).toBe(15); // gw99 excluded
+    });
+
+    it('ranks by points and orders disqualified managers last', () => {
+        const standings = computeLeagueStandings(
+            [
+                scored('winner', 21, 30),
+                scored('dq', 21, 100, true),
+                scored('dq', 22, 100, true), // 2 autopicks => DQ
+                scored('mid', 21, 20),
+            ],
+            LEAGUE_GWS,
+        );
+        expect(standings.map((s) => s.manager)).toEqual(['winner', 'mid', 'dq']);
+        expect(standings.find((s) => s.manager === 'dq')?.disqualified).toBe(true);
+        expect(standings[0]?.rank).toBe(1);
+    });
+});
+
+describe('getQualifiers', () => {
+    it('takes the top non-disqualified managers', () => {
+        const standings = computeLeagueStandings(
+            [
+                scored('a', 21, 30),
+                scored('b', 21, 20),
+                scored('c', 21, 40, true),
+                scored('c', 22, 1, true), // DQ despite high points
+            ],
+            LEAGUE_GWS,
+        );
+        expect(getQualifiers(standings, 2)).toEqual(['a', 'b']);
+    });
+});

--- a/draft/app/cup/lib/cup-standings.ts
+++ b/draft/app/cup/lib/cup-standings.ts
@@ -1,0 +1,66 @@
+/* Location: app/cup/lib/cup-standings.ts */
+
+import type { ManagerId } from '../../teams/types/team-types';
+import { isDisqualified, QUALIFYING_PLACES } from './cup-rules';
+
+/** A scored league-stage submission (points already computed). */
+export interface ScoredSubmission {
+    manager: ManagerId;
+    gameweek: number;
+    points: number;
+    isAutopick: boolean;
+}
+
+export interface CupStanding {
+    manager: ManagerId;
+    points: number;
+    autopickCount: number;
+    disqualified: boolean;
+    rank: number;
+}
+
+/**
+ * League-stage standings across the configured league gameweeks: total points
+ * per manager, autopick count, and DQ flag (2+ autopicks). Disqualified managers
+ * sink to the bottom; the rest are ranked by points descending.
+ */
+export function computeLeagueStandings(scored: ScoredSubmission[], leagueGameweeks: number[]): CupStanding[] {
+    const gameweeks = new Set(leagueGameweeks);
+    const byManager = new Map<ManagerId, { points: number; autopickCount: number }>();
+
+    for (const submission of scored) {
+        if (!gameweeks.has(submission.gameweek)) continue;
+        const entry = byManager.get(submission.manager) ?? { points: 0, autopickCount: 0 };
+        entry.points += submission.points;
+        if (submission.isAutopick) entry.autopickCount += 1;
+        byManager.set(submission.manager, entry);
+    }
+
+    const standings = Array.from(byManager.entries()).map(([manager, entry]) => ({
+        manager,
+        points: entry.points,
+        autopickCount: entry.autopickCount,
+        disqualified: isDisqualified(entry.autopickCount),
+        rank: 0,
+    }));
+
+    standings.sort((a, b) => {
+        // Disqualified managers always rank below non-disqualified ones.
+        if (a.disqualified !== b.disqualified) return a.disqualified ? 1 : -1;
+        return b.points - a.points;
+    });
+
+    standings.forEach((standing, index) => {
+        standing.rank = index + 1;
+    });
+
+    return standings;
+}
+
+/** The managers who qualify for the Round of 16 — top non-disqualified managers. */
+export function getQualifiers(standings: CupStanding[], places = QUALIFYING_PLACES): ManagerId[] {
+    return standings
+        .filter((standing) => !standing.disqualified)
+        .slice(0, places)
+        .map((standing) => standing.manager);
+}

--- a/draft/app/cup/lib/cup-submission.test.ts
+++ b/draft/app/cup/lib/cup-submission.test.ts
@@ -1,0 +1,42 @@
+/* Location: app/cup/lib/cup-submission.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { validateCupSubmission } from './cup-submission';
+
+const SQUAD = [10, 11, 12, 13, 14, 15];
+
+describe('validateCupSubmission', () => {
+    it('accepts a valid selection of the required size', () => {
+        const result = validateCupSubmission({ players: [10, 11, 12, 13], playersRequired: 4, squadCodes: SQUAD });
+        expect(result).toEqual({ valid: true, errors: [] });
+    });
+
+    it('rejects the wrong number of players', () => {
+        const result = validateCupSubmission({ players: [10, 11, 12], playersRequired: 4, squadCodes: SQUAD });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('exactly 4');
+    });
+
+    it('rejects duplicate picks', () => {
+        const result = validateCupSubmission({ players: [10, 10, 11, 12], playersRequired: 4, squadCodes: SQUAD });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('same player'))).toBe(true);
+    });
+
+    it('rejects players not in the squad', () => {
+        const result = validateCupSubmission({ players: [10, 11, 12, 99], playersRequired: 4, squadCodes: SQUAD });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('not in your squad'))).toBe(true);
+    });
+
+    it('rejects players reused from the other leg of the round', () => {
+        const result = validateCupSubmission({
+            players: [10, 11, 12, 13],
+            playersRequired: 4,
+            squadCodes: SQUAD,
+            usedPlayers: [13],
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('other leg'))).toBe(true);
+    });
+});

--- a/draft/app/cup/lib/cup-submission.ts
+++ b/draft/app/cup/lib/cup-submission.ts
@@ -1,0 +1,46 @@
+/* Location: app/cup/lib/cup-submission.ts */
+
+import { findReusedPlayers } from './cup-rules';
+
+export interface CupSubmissionValidation {
+    valid: boolean;
+    errors: string[];
+}
+
+/**
+ * Validate a manager's cup team selection against the round's rules:
+ * - exactly the required number of players
+ * - no duplicate picks
+ * - every pick is in the manager's squad
+ * - no player reused from the other leg of the same round
+ */
+export function validateCupSubmission(params: {
+    players: number[];
+    playersRequired: number;
+    squadCodes: number[];
+    usedPlayers?: number[];
+}): CupSubmissionValidation {
+    const { players, playersRequired, squadCodes, usedPlayers = [] } = params;
+    const errors: string[] = [];
+
+    if (players.length !== playersRequired) {
+        errors.push(`Select exactly ${playersRequired} players (you selected ${players.length}).`);
+    }
+
+    if (new Set(players).size !== players.length) {
+        errors.push('You cannot pick the same player more than once.');
+    }
+
+    const squad = new Set(squadCodes);
+    const notInSquad = players.filter((code) => !squad.has(code));
+    if (notInSquad.length > 0) {
+        errors.push(`These players are not in your squad: ${notInSquad.join(', ')}.`);
+    }
+
+    const reused = findReusedPlayers(players, usedPlayers);
+    if (reused.length > 0) {
+        errors.push(`These players were already used in the other leg of this round: ${reused.join(', ')}.`);
+    }
+
+    return { valid: errors.length === 0, errors };
+}

--- a/draft/app/cup/lib/cup-visibility.test.ts
+++ b/draft/app/cup/lib/cup-visibility.test.ts
@@ -1,0 +1,30 @@
+/* Location: app/cup/lib/cup-visibility.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { getTeamVisibility, isRevealed } from './cup-visibility';
+
+describe('cup team visibility', () => {
+    it('is not_submitted when there is no team on record', () => {
+        expect(getTeamVisibility({ hasSubmission: false, deadlinePassed: true, subsConfirmed: true })).toBe(
+            'not_submitted',
+        );
+    });
+
+    it('stays hidden after the deadline while subs are unconfirmed', () => {
+        expect(getTeamVisibility({ hasSubmission: true, deadlinePassed: true, subsConfirmed: false })).toBe(
+            'submitted_hidden',
+        );
+    });
+
+    it('stays hidden before the deadline even when subs are confirmed', () => {
+        expect(getTeamVisibility({ hasSubmission: true, deadlinePassed: false, subsConfirmed: true })).toBe(
+            'submitted_hidden',
+        );
+    });
+
+    it('reveals only once the deadline has passed AND subs are confirmed', () => {
+        const visibility = getTeamVisibility({ hasSubmission: true, deadlinePassed: true, subsConfirmed: true });
+        expect(visibility).toBe('revealed');
+        expect(isRevealed(visibility)).toBe(true);
+    });
+});

--- a/draft/app/cup/lib/cup-visibility.ts
+++ b/draft/app/cup/lib/cup-visibility.ts
@@ -1,0 +1,24 @@
+/* Location: app/cup/lib/cup-visibility.ts */
+
+/**
+ * Public visibility of a manager's cup team for a round.
+ * - not_submitted: no team on record
+ * - submitted_hidden: submitted, but not yet revealable (deadline not passed, or
+ *   the manager's subs are not confirmed yet — either keeps the team hidden)
+ * - revealed: deadline passed AND subs confirmed, so the team + points are shown
+ */
+export type CupTeamVisibility = 'not_submitted' | 'submitted_hidden' | 'revealed';
+
+export function getTeamVisibility(params: {
+    hasSubmission: boolean;
+    deadlinePassed: boolean;
+    subsConfirmed: boolean;
+}): CupTeamVisibility {
+    if (!params.hasSubmission) return 'not_submitted';
+    if (params.deadlinePassed && params.subsConfirmed) return 'revealed';
+    return 'submitted_hidden';
+}
+
+export function isRevealed(visibility: CupTeamVisibility): boolean {
+    return visibility === 'revealed';
+}

--- a/draft/app/cup/lib/knockout.test.ts
+++ b/draft/app/cup/lib/knockout.test.ts
@@ -1,0 +1,62 @@
+/* Location: app/cup/lib/knockout.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import { advanceWinners, fisherYatesShuffle, pairIntoMatchups, resolveTie } from './knockout';
+
+describe('fisherYatesShuffle', () => {
+    it('is a permutation and is deterministic for a fixed random source', () => {
+        const items = [1, 2, 3, 4, 5];
+        const random = () => 0; // always picks index 0 in the swap
+        const shuffled = fisherYatesShuffle(items, random);
+        expect([...shuffled].sort()).toEqual([1, 2, 3, 4, 5]);
+        expect(fisherYatesShuffle(items, () => 0)).toEqual(shuffled); // deterministic
+        expect(items).toEqual([1, 2, 3, 4, 5]); // input not mutated
+    });
+});
+
+describe('pairIntoMatchups', () => {
+    it('pairs consecutive managers into ties', () => {
+        const matchups = pairIntoMatchups(['a', 'b', 'c', 'd'], 'r16');
+        expect(matchups).toHaveLength(2);
+        expect(matchups[0]).toMatchObject({ tie: 0, home: 'a', away: 'b' });
+        expect(matchups[1]).toMatchObject({ tie: 1, home: 'c', away: 'd' });
+    });
+
+    it('gives a bye when an opponent is missing', () => {
+        const matchups = pairIntoMatchups(['a', null], 'sf');
+        expect(matchups[0]).toMatchObject({ home: 'a', away: null });
+    });
+});
+
+describe('resolveTie', () => {
+    const tie = { stage: 'r16' as const, tie: 0, home: 'a', away: 'b' };
+
+    it('adds the two legs and picks the higher aggregate', () => {
+        const resolved = resolveTie(tie, { homeLeg1: 5, awayLeg1: 4, homeLeg2: 2, awayLeg2: 1 });
+        expect(resolved.homeAggregate).toBe(7);
+        expect(resolved.awayAggregate).toBe(5);
+        expect(resolved.winner).toBe('a');
+    });
+
+    it('leaves the winner undefined on an aggregate draw', () => {
+        const resolved = resolveTie(tie, { homeLeg1: 3, awayLeg1: 3, homeLeg2: 2, awayLeg2: 2 });
+        expect(resolved.winner).toBeUndefined();
+    });
+
+    it('advances the present manager on a bye', () => {
+        const bye = { stage: 'r16' as const, tie: 0, home: 'a', away: null };
+        expect(resolveTie(bye, { homeLeg1: 0, awayLeg1: 0, homeLeg2: 0, awayLeg2: 0 }).winner).toBe('a');
+    });
+});
+
+describe('advanceWinners', () => {
+    it('pairs winners of consecutive ties into the next round', () => {
+        const resolved = [
+            { stage: 'r16' as const, tie: 0, home: 'a', away: 'b', winner: 'a' },
+            { stage: 'r16' as const, tie: 1, home: 'c', away: 'd', winner: 'd' },
+        ];
+        const next = advanceWinners(resolved, 'qf');
+        expect(next).toHaveLength(1);
+        expect(next[0]).toMatchObject({ stage: 'qf', home: 'a', away: 'd' });
+    });
+});

--- a/draft/app/cup/lib/knockout.ts
+++ b/draft/app/cup/lib/knockout.ts
@@ -1,0 +1,72 @@
+/* Location: app/cup/lib/knockout.ts */
+
+import type { ManagerId } from '../../teams/types/team-types';
+import type { CupMatchup, CupStageId } from '../types/cup-types';
+
+/**
+ * Fisher–Yates shuffle with an injectable random source, so the R16 draw is
+ * random in production but deterministic (and testable) when given a seeded PRNG.
+ */
+export function fisherYatesShuffle<T>(items: T[], random: () => number): T[] {
+    const result = [...items];
+    for (let i = result.length - 1; i > 0; i--) {
+        const j = Math.floor(random() * (i + 1));
+        const a = result[i];
+        const b = result[j];
+        if (a !== undefined && b !== undefined) {
+            result[i] = b;
+            result[j] = a;
+        }
+    }
+    return result;
+}
+
+/**
+ * Pair a drawn/ordered list of managers into ties: (0 vs 1), (2 vs 3), … A null
+ * entry (odd count or unfilled slot) yields a bye — home set, away null.
+ */
+export function pairIntoMatchups(order: (ManagerId | null)[], stage: CupStageId): CupMatchup[] {
+    const matchups: CupMatchup[] = [];
+    for (let i = 0; i < order.length; i += 2) {
+        matchups.push({
+            stage,
+            tie: i / 2,
+            home: order[i] ?? null,
+            away: order[i + 1] ?? null,
+            winner: undefined,
+        });
+    }
+    return matchups;
+}
+
+/**
+ * Resolve a two-legged tie from its four leg scores, setting aggregates and the
+ * winner. Aggregate = home(leg1)+home(leg2) vs away(leg1)+away(leg2). A bye
+ * (missing opponent) advances the present manager. Returns undefined winner on
+ * a draw (caller decides the tiebreak).
+ */
+export function resolveTie(
+    matchup: CupMatchup,
+    legScores: { homeLeg1: number; awayLeg1: number; homeLeg2: number; awayLeg2: number },
+): CupMatchup {
+    if (matchup.home && !matchup.away) return { ...matchup, winner: matchup.home };
+    if (matchup.away && !matchup.home) return { ...matchup, winner: matchup.away };
+
+    const homeAggregate = legScores.homeLeg1 + legScores.homeLeg2;
+    const awayAggregate = legScores.awayLeg1 + legScores.awayLeg2;
+    let winner: ManagerId | null | undefined;
+    if (homeAggregate > awayAggregate) winner = matchup.home;
+    else if (awayAggregate > homeAggregate) winner = matchup.away;
+    else winner = undefined; // draw — needs a tiebreak
+
+    return { ...matchup, homeAggregate, awayAggregate, winner };
+}
+
+/**
+ * Build the next round from resolved matchups: winners of consecutive ties meet.
+ * Winners must be in bracket order.
+ */
+export function advanceWinners(resolved: CupMatchup[], nextStage: CupStageId): CupMatchup[] {
+    const winners = resolved.map((matchup) => matchup.winner ?? null);
+    return pairIntoMatchups(winners, nextStage);
+}

--- a/draft/app/cup/server/actions/submit-cup-team.action.ts
+++ b/draft/app/cup/server/actions/submit-cup-team.action.ts
@@ -1,0 +1,78 @@
+/* Location: app/cup/server/actions/submit-cup-team.action.ts */
+
+import { addCupSubmission, readCupConfig, readCupSubmissions } from '../../../_shared/lib/sheets/cup';
+import { getTeamsForGameweek } from '../../../scoring/server/services/division-teams.service';
+import type { DivisionId } from '../../../teams/types/team-types';
+import { getGameweekForStage, getRoundForGameweek } from '../../lib/cup-config';
+import { getCupSquad } from '../../lib/cup-squad';
+import { validateCupSubmission } from '../../lib/cup-submission';
+import type { CupStageId, ProcessedCupSheetData } from '../../types/cup-types';
+
+export interface CupSubmissionResult {
+    success: boolean;
+    error?: string;
+    message?: string;
+}
+
+/**
+ * Handle a cup team submission: re-validate against the round rules server-side
+ * (never trust the client), then append it to the Cup sheet as PENDING.
+ */
+export async function handleCupSubmission(input: {
+    manager: string;
+    division: DivisionId;
+    gameweek: number;
+    players: number[];
+}): Promise<CupSubmissionResult> {
+    const { manager, division, gameweek, players } = input;
+
+    if (!manager || !division || !gameweek) {
+        return { success: false, error: 'Missing manager, division or gameweek.' };
+    }
+
+    const [cupConfig, submissions] = await Promise.all([readCupConfig(), readCupSubmissions()]);
+    const round = getRoundForGameweek(cupConfig, gameweek);
+    if (!round) {
+        return { success: false, error: `Gameweek ${gameweek} is not part of the cup.` };
+    }
+
+    const team = await getTeamsForGameweek(division, manager, gameweek);
+    if (!team) {
+        return { success: false, error: 'Could not find your squad for this gameweek.' };
+    }
+    const squadCodes = getCupSquad(team.roster).map((player) => player.code);
+
+    let usedPlayers: number[] = [];
+    if (round.twoLegged && round.leg === 2) {
+        const otherGameweek = getGameweekForStage(cupConfig, round.stage, 1);
+        if (otherGameweek !== null) {
+            usedPlayers = submissions.find((s) => s.manager === manager && s.gameweek === otherGameweek)?.players ?? [];
+        }
+    }
+
+    const validation = validateCupSubmission({
+        players,
+        playersRequired: round.playersRequired,
+        squadCodes,
+        usedPlayers,
+    });
+    if (!validation.valid) {
+        return { success: false, error: validation.errors.join(' ') };
+    }
+
+    const submission: ProcessedCupSheetData = {
+        status: '', // pending until an admin confirms
+        timestamp: new Date(),
+        manager,
+        division,
+        gameweek,
+        stage: round.stage as CupStageId,
+        leg: round.leg,
+        players,
+        submittedByAdmin: false,
+        adminReason: '',
+    };
+
+    await addCupSubmission(submission);
+    return { success: true, message: 'Cup team submitted.' };
+}

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -4,6 +4,7 @@ import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
 import type { UserTeamsSheetData } from '../../teams/types/team-types';
 import { getGameweekForStage, getRoundForGameweek, resolveCupRounds } from '../lib/cup-config';
 import { isDeadlinePassed, isSubmissionOpen } from '../lib/cup-deadlines';
+import type { CupFixture } from '../lib/cup-fixtures';
 import { CUP_STAGES } from '../lib/cup-rules';
 import { buildGameweekPointsMap, type PlayerPointsRow, scoreSubmission } from '../lib/cup-scoring';
 import { getCupSquad } from '../lib/cup-squad';
@@ -132,9 +133,10 @@ export async function getCupSubmitData(input: {
     gameweekData: GameWeekData;
     cupConfig: CupConfig;
     submissions: ProcessedCupSheetData[];
+    fixtures: CupFixture[];
     now?: Date;
 }): Promise<CupSubmitPageData> {
-    const { userTeams, selectedUser, gameweekData, cupConfig, submissions } = input;
+    const { userTeams, selectedUser, gameweekData, cupConfig, submissions, fixtures } = input;
     const now = input.now ?? new Date();
     const gameweek = gameweekData.fplEvent.id;
     const round = getRoundForGameweek(cupConfig, gameweek);
@@ -161,6 +163,7 @@ export async function getCupSubmitData(input: {
         deadline,
         selectedGameweek: gameweek,
         gameweekOptions,
+        fixtures,
     };
 
     if (!selectedUser || !round) return empty;

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -42,7 +42,7 @@ export function getCupPageData(input: {
     submissions: ProcessedCupSheetData[];
     pointsRows: PlayerPointsRow[];
     now?: Date;
-}): Omit<CupPageData, 'bracket'> {
+}): Omit<CupPageData, 'bracket' | 'fixtures' | 'userTeams' | 'selectedUserId'> {
     const { userTeams, gameweekData, cupConfig, submissions, pointsRows } = input;
     const now = input.now ?? new Date();
     const gameweek = gameweekData.fplEvent.id;
@@ -127,13 +127,14 @@ export function getCupStandings(input: {
  * leg of this round (which they cannot reuse).
  */
 export async function getCupSubmitData(input: {
+    userTeams: UserTeamsSheetData[];
     selectedUser: UserTeamsSheetData | undefined;
     currentGameweekData: GameWeekData;
     cupConfig: CupConfig;
     submissions: ProcessedCupSheetData[];
     now?: Date;
 }): Promise<CupSubmitPageData> {
-    const { selectedUser, currentGameweekData, cupConfig, submissions } = input;
+    const { userTeams, selectedUser, currentGameweekData, cupConfig, submissions } = input;
     const now = input.now ?? new Date();
     const gameweek = currentGameweekData.fplEvent.id;
     const round = getRoundForGameweek(cupConfig, gameweek);
@@ -144,6 +145,7 @@ export async function getCupSubmitData(input: {
     const empty: CupSubmitPageData = {
         hasConfig: !!round,
         round,
+        userTeams,
         selectedUserId: selectedUser?.userId ?? null,
         selectedUserName: selectedUser?.userName ?? null,
         division: selectedUser?.divisionId ?? null,

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -129,18 +129,23 @@ export function getCupStandings(input: {
 export async function getCupSubmitData(input: {
     userTeams: UserTeamsSheetData[];
     selectedUser: UserTeamsSheetData | undefined;
-    currentGameweekData: GameWeekData;
+    gameweekData: GameWeekData;
     cupConfig: CupConfig;
     submissions: ProcessedCupSheetData[];
     now?: Date;
 }): Promise<CupSubmitPageData> {
-    const { userTeams, selectedUser, currentGameweekData, cupConfig, submissions } = input;
+    const { userTeams, selectedUser, gameweekData, cupConfig, submissions } = input;
     const now = input.now ?? new Date();
-    const gameweek = currentGameweekData.fplEvent.id;
+    const gameweek = gameweekData.fplEvent.id;
     const round = getRoundForGameweek(cupConfig, gameweek);
-    const submissionOpen = isSubmissionOpen(currentGameweekData, now);
-    const rawDeadline = currentGameweekData.fplEvent.deadline_time;
+    const submissionOpen = isSubmissionOpen(gameweekData, now);
+    const rawDeadline = gameweekData.fplEvent.deadline_time;
     const deadline = typeof rawDeadline === 'string' ? rawDeadline : rawDeadline.toISOString();
+
+    const gameweekOptions: CupGameweekOption[] = resolveCupRounds(cupConfig).map((r) => ({
+        gameweek: r.gameweek,
+        label: `${CUP_STAGES[r.stage].label}${r.twoLegged ? ` L${r.leg}` : ''} · GW${r.gameweek}`,
+    }));
 
     const empty: CupSubmitPageData = {
         hasConfig: !!round,
@@ -154,6 +159,8 @@ export async function getCupSubmitData(input: {
         usedPlayers: [],
         submissionOpen,
         deadline,
+        selectedGameweek: gameweek,
+        gameweekOptions,
     };
 
     if (!selectedUser || !round) return empty;

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -2,13 +2,20 @@
 
 import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
 import type { UserTeamsSheetData } from '../../teams/types/team-types';
-import { getGameweekForStage, getRoundForGameweek } from '../lib/cup-config';
+import { getGameweekForStage, getRoundForGameweek, resolveCupRounds } from '../lib/cup-config';
 import { isDeadlinePassed, isSubmissionOpen } from '../lib/cup-deadlines';
+import { CUP_STAGES } from '../lib/cup-rules';
 import { buildGameweekPointsMap, type PlayerPointsRow, scoreSubmission } from '../lib/cup-scoring';
 import { getCupSquad } from '../lib/cup-squad';
 import { computeLeagueStandings, getQualifiers, type ScoredSubmission } from '../lib/cup-standings';
 import { getTeamVisibility } from '../lib/cup-visibility';
-import type { CupOverviewRow, CupPageData, CupQualifier, CupSubmitPageData } from '../types/cup-page-types';
+import type {
+    CupGameweekOption,
+    CupOverviewRow,
+    CupPageData,
+    CupQualifier,
+    CupSubmitPageData,
+} from '../types/cup-page-types';
 import type { CupConfig, ProcessedCupSheetData } from '../types/cup-types';
 
 /** A submission's subs count as confirmed once an admin has approved it (Status = 'Y'). */
@@ -30,17 +37,17 @@ function findSubmission(
  */
 export function getCupPageData(input: {
     userTeams: UserTeamsSheetData[];
-    currentGameweekData: GameWeekData;
+    gameweekData: GameWeekData;
     cupConfig: CupConfig;
     submissions: ProcessedCupSheetData[];
     pointsRows: PlayerPointsRow[];
     now?: Date;
 }): Omit<CupPageData, 'bracket'> {
-    const { userTeams, currentGameweekData, cupConfig, submissions, pointsRows } = input;
+    const { userTeams, gameweekData, cupConfig, submissions, pointsRows } = input;
     const now = input.now ?? new Date();
-    const gameweek = currentGameweekData.fplEvent.id;
+    const gameweek = gameweekData.fplEvent.id;
     const round = getRoundForGameweek(cupConfig, gameweek);
-    const deadlinePassed = isDeadlinePassed(currentGameweekData, now);
+    const deadlinePassed = isDeadlinePassed(gameweekData, now);
     const currentPoints = buildGameweekPointsMap(pointsRows, gameweek);
 
     const rows: CupOverviewRow[] = userTeams.map((team) => {
@@ -64,7 +71,22 @@ export function getCupPageData(input: {
 
     const { standings, qualifiers } = getCupStandings({ userTeams, cupConfig, submissions, pointsRows });
 
-    return { hasConfig: !!round, round, gameweek, deadlinePassed, rows, standings, qualifiers };
+    const gameweekOptions: CupGameweekOption[] = resolveCupRounds(cupConfig).map((r) => ({
+        gameweek: r.gameweek,
+        label: `${CUP_STAGES[r.stage].label}${r.twoLegged ? ` L${r.leg}` : ''} · GW${r.gameweek}`,
+    }));
+
+    return {
+        hasConfig: !!round,
+        round,
+        gameweek,
+        deadlinePassed,
+        rows,
+        standings,
+        qualifiers,
+        selectedGameweek: gameweek,
+        gameweekOptions,
+    };
 }
 
 /**

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -103,12 +103,18 @@ export function getCupStandings(input: {
 }) {
     const { userTeams, cupConfig, submissions, pointsRows } = input;
 
+    // Build one points map per league gameweek up front rather than rebuilding it (an
+    // O(players) pass) for every submission — scoring is on the app's hot path.
+    const leaguePointsMaps = new Map(
+        cupConfig.league.map((gameweek) => [gameweek, buildGameweekPointsMap(pointsRows, gameweek)]),
+    );
+
     const scored: ScoredSubmission[] = submissions
         .filter((submission) => cupConfig.league.includes(submission.gameweek))
         .map((submission) => ({
             manager: submission.manager,
             gameweek: submission.gameweek,
-            points: scoreSubmission(submission.players, buildGameweekPointsMap(pointsRows, submission.gameweek)),
+            points: scoreSubmission(submission.players, leaguePointsMaps.get(submission.gameweek) ?? new Map()),
             isAutopick: submission.adminReason === 'autopick',
         }));
 

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -35,7 +35,7 @@ export function getCupPageData(input: {
     submissions: ProcessedCupSheetData[];
     pointsRows: PlayerPointsRow[];
     now?: Date;
-}): CupPageData {
+}): Omit<CupPageData, 'bracket'> {
     const { userTeams, currentGameweekData, cupConfig, submissions, pointsRows } = input;
     const now = input.now ?? new Date();
     const gameweek = currentGameweekData.fplEvent.id;
@@ -62,8 +62,24 @@ export function getCupPageData(input: {
         };
     });
 
-    // League-stage standings across every configured league gameweek, using the
-    // site's existing per-player league points (no double counting).
+    const { standings, qualifiers } = getCupStandings({ userTeams, cupConfig, submissions, pointsRows });
+
+    return { hasConfig: !!round, round, gameweek, deadlinePassed, rows, standings, qualifiers };
+}
+
+/**
+ * League-stage standings + qualifiers across every configured league gameweek,
+ * using the site's existing per-player league points (no double counting).
+ * Shared by the overview and the admin draw generation.
+ */
+export function getCupStandings(input: {
+    userTeams: UserTeamsSheetData[];
+    cupConfig: CupConfig;
+    submissions: ProcessedCupSheetData[];
+    pointsRows: PlayerPointsRow[];
+}) {
+    const { userTeams, cupConfig, submissions, pointsRows } = input;
+
     const scored: ScoredSubmission[] = submissions
         .filter((submission) => cupConfig.league.includes(submission.gameweek))
         .map((submission) => ({
@@ -80,7 +96,7 @@ export function getCupPageData(input: {
         return { manager, userName: userNameById.get(manager) ?? manager, rank: standing?.rank ?? 0 };
     });
 
-    return { hasConfig: !!round, round, gameweek, deadlinePassed, rows, standings, qualifiers };
+    return { standings, qualifiers };
 }
 
 /**

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -4,9 +4,11 @@ import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
 import type { UserTeamsSheetData } from '../../teams/types/team-types';
 import { getGameweekForStage, getRoundForGameweek } from '../lib/cup-config';
 import { isDeadlinePassed, isSubmissionOpen } from '../lib/cup-deadlines';
+import { buildGameweekPointsMap, type PlayerPointsRow, scoreSubmission } from '../lib/cup-scoring';
 import { getCupSquad } from '../lib/cup-squad';
+import { computeLeagueStandings, getQualifiers, type ScoredSubmission } from '../lib/cup-standings';
 import { getTeamVisibility } from '../lib/cup-visibility';
-import type { CupOverviewRow, CupPageData, CupSubmitPageData } from '../types/cup-page-types';
+import type { CupOverviewRow, CupPageData, CupQualifier, CupSubmitPageData } from '../types/cup-page-types';
 import type { CupConfig, ProcessedCupSheetData } from '../types/cup-types';
 
 /** A submission's subs count as confirmed once an admin has approved it (Status = 'Y'). */
@@ -31,13 +33,15 @@ export function getCupPageData(input: {
     currentGameweekData: GameWeekData;
     cupConfig: CupConfig;
     submissions: ProcessedCupSheetData[];
+    pointsRows: PlayerPointsRow[];
     now?: Date;
 }): CupPageData {
-    const { userTeams, currentGameweekData, cupConfig, submissions } = input;
+    const { userTeams, currentGameweekData, cupConfig, submissions, pointsRows } = input;
     const now = input.now ?? new Date();
     const gameweek = currentGameweekData.fplEvent.id;
     const round = getRoundForGameweek(cupConfig, gameweek);
     const deadlinePassed = isDeadlinePassed(currentGameweekData, now);
+    const currentPoints = buildGameweekPointsMap(pointsRows, gameweek);
 
     const rows: CupOverviewRow[] = userTeams.map((team) => {
         const submission = findSubmission(submissions, team.userId, gameweek);
@@ -54,11 +58,29 @@ export function getCupPageData(input: {
             division: team.divisionId,
             visibility,
             players: revealed ? submission.players : null,
-            points: null,
+            points: revealed ? scoreSubmission(submission.players, currentPoints) : null,
         };
     });
 
-    return { hasConfig: !!round, round, gameweek, deadlinePassed, rows };
+    // League-stage standings across every configured league gameweek, using the
+    // site's existing per-player league points (no double counting).
+    const scored: ScoredSubmission[] = submissions
+        .filter((submission) => cupConfig.league.includes(submission.gameweek))
+        .map((submission) => ({
+            manager: submission.manager,
+            gameweek: submission.gameweek,
+            points: scoreSubmission(submission.players, buildGameweekPointsMap(pointsRows, submission.gameweek)),
+            isAutopick: submission.adminReason === 'autopick',
+        }));
+
+    const standings = computeLeagueStandings(scored, cupConfig.league);
+    const userNameById = new Map(userTeams.map((team) => [team.userId, team.userName]));
+    const qualifiers: CupQualifier[] = getQualifiers(standings).map((manager) => {
+        const standing = standings.find((s) => s.manager === manager);
+        return { manager, userName: userNameById.get(manager) ?? manager, rank: standing?.rank ?? 0 };
+    });
+
+    return { hasConfig: !!round, round, gameweek, deadlinePassed, rows, standings, qualifiers };
 }
 
 /**

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -1,0 +1,121 @@
+/* Location: app/cup/server/cup.server.ts */
+
+import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
+import type { UserTeamsSheetData } from '../../teams/types/team-types';
+import { getGameweekForStage, getRoundForGameweek } from '../lib/cup-config';
+import { isDeadlinePassed, isSubmissionOpen } from '../lib/cup-deadlines';
+import { getCupSquad } from '../lib/cup-squad';
+import { getTeamVisibility } from '../lib/cup-visibility';
+import type { CupOverviewRow, CupPageData, CupSubmitPageData } from '../types/cup-page-types';
+import type { CupConfig, ProcessedCupSheetData } from '../types/cup-types';
+
+/** A submission's subs count as confirmed once an admin has approved it (Status = 'Y'). */
+function isConfirmed(submission: ProcessedCupSheetData | undefined): boolean {
+    return submission?.status === 'Y';
+}
+
+function findSubmission(
+    submissions: ProcessedCupSheetData[],
+    manager: string,
+    gameweek: number,
+): ProcessedCupSheetData | undefined {
+    return submissions.find((s) => s.manager === manager && s.gameweek === gameweek);
+}
+
+/**
+ * Build the cross-division cup overview for the current gameweek's round: every
+ * manager with their team's visibility (hidden until deadline + subs confirmed).
+ */
+export function getCupPageData(input: {
+    userTeams: UserTeamsSheetData[];
+    currentGameweekData: GameWeekData;
+    cupConfig: CupConfig;
+    submissions: ProcessedCupSheetData[];
+    now?: Date;
+}): CupPageData {
+    const { userTeams, currentGameweekData, cupConfig, submissions } = input;
+    const now = input.now ?? new Date();
+    const gameweek = currentGameweekData.fplEvent.id;
+    const round = getRoundForGameweek(cupConfig, gameweek);
+    const deadlinePassed = isDeadlinePassed(currentGameweekData, now);
+
+    const rows: CupOverviewRow[] = userTeams.map((team) => {
+        const submission = findSubmission(submissions, team.userId, gameweek);
+        const visibility = getTeamVisibility({
+            hasSubmission: !!submission,
+            deadlinePassed,
+            subsConfirmed: isConfirmed(submission),
+        });
+        const revealed = visibility === 'revealed' && submission;
+        return {
+            manager: team.userId,
+            userName: team.userName,
+            teamName: team.teamName,
+            division: team.divisionId,
+            visibility,
+            players: revealed ? submission.players : null,
+            points: null,
+        };
+    });
+
+    return { hasConfig: !!round, round, gameweek, deadlinePassed, rows };
+}
+
+/**
+ * Build the submission context for the selected manager: their squad to pick
+ * from, any existing submission, and the players they already used in the other
+ * leg of this round (which they cannot reuse).
+ */
+export async function getCupSubmitData(input: {
+    selectedUser: UserTeamsSheetData | undefined;
+    currentGameweekData: GameWeekData;
+    cupConfig: CupConfig;
+    submissions: ProcessedCupSheetData[];
+    now?: Date;
+}): Promise<CupSubmitPageData> {
+    const { selectedUser, currentGameweekData, cupConfig, submissions } = input;
+    const now = input.now ?? new Date();
+    const gameweek = currentGameweekData.fplEvent.id;
+    const round = getRoundForGameweek(cupConfig, gameweek);
+    const submissionOpen = isSubmissionOpen(currentGameweekData, now);
+    const rawDeadline = currentGameweekData.fplEvent.deadline_time;
+    const deadline = typeof rawDeadline === 'string' ? rawDeadline : rawDeadline.toISOString();
+
+    const empty: CupSubmitPageData = {
+        hasConfig: !!round,
+        round,
+        selectedUserId: selectedUser?.userId ?? null,
+        selectedUserName: selectedUser?.userName ?? null,
+        division: selectedUser?.divisionId ?? null,
+        squad: [],
+        existingPlayers: [],
+        usedPlayers: [],
+        submissionOpen,
+        deadline,
+    };
+
+    if (!selectedUser || !round) return empty;
+
+    // Load the manager's roster for this gameweek from their own division.
+    const { getTeamsForGameweek } = await import('../../scoring/server/services/division-teams.service');
+    const team = await getTeamsForGameweek(selectedUser.divisionId, selectedUser.userId, gameweek);
+    const squad = team ? getCupSquad(team.roster) : [];
+
+    const existing = findSubmission(submissions, selectedUser.userId, gameweek);
+
+    // For leg 2 of a two-legged round, gather the players used in leg 1.
+    let usedPlayers: number[] = [];
+    if (round.twoLegged && round.leg === 2) {
+        const otherGameweek = getGameweekForStage(cupConfig, round.stage, 1);
+        if (otherGameweek !== null) {
+            usedPlayers = findSubmission(submissions, selectedUser.userId, otherGameweek)?.players ?? [];
+        }
+    }
+
+    return {
+        ...empty,
+        squad,
+        existingPlayers: existing?.players ?? [],
+        usedPlayers,
+    };
+}

--- a/draft/app/cup/server/cup.server.ts
+++ b/draft/app/cup/server/cup.server.ts
@@ -43,7 +43,7 @@ export function getCupPageData(input: {
     submissions: ProcessedCupSheetData[];
     pointsRows: PlayerPointsRow[];
     now?: Date;
-}): Omit<CupPageData, 'bracket' | 'fixtures' | 'userTeams' | 'selectedUserId'> {
+}): Omit<CupPageData, 'bracket' | 'fixtures' | 'stageMatchups' | 'userTeams' | 'selectedUserId'> {
     const { userTeams, gameweekData, cupConfig, submissions, pointsRows } = input;
     const now = input.now ?? new Date();
     const gameweek = gameweekData.fplEvent.id;

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -73,4 +73,6 @@ export interface CupSubmitPageData {
     /** The gameweek being submitted for, and all selectable cup gameweeks. */
     selectedGameweek: number;
     gameweekOptions: CupGameweekOption[];
+    /** Real-world fixtures for the viewed gameweek. */
+    fixtures: CupFixture[];
 }

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -2,6 +2,7 @@
 
 import type { DivisionId, ManagerId, UserTeamsSheetData } from '../../teams/types/team-types';
 import type { CupFixture } from '../lib/cup-fixtures';
+import type { CupMatchupView } from '../lib/cup-matchups';
 import type { CupSquadPlayer } from '../lib/cup-squad';
 import type { CupStanding } from '../lib/cup-standings';
 import type { CupTeamVisibility } from '../lib/cup-visibility';
@@ -46,6 +47,8 @@ export interface CupPageData {
     gameweekOptions: CupGameweekOption[];
     /** Real-world fixtures for the viewed gameweek. */
     fixtures: CupFixture[];
+    /** Head-to-head matchups for the viewed knockout stage (empty for the league stage). */
+    stageMatchups: CupMatchupView[];
     /** Manager selection (shared cup header). */
     userTeams: UserTeamsSheetData[];
     selectedUserId: string | null;

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -1,0 +1,40 @@
+/* Location: app/cup/types/cup-page-types.ts */
+
+import type { DivisionId, ManagerId } from '../../teams/types/team-types';
+import type { CupSquadPlayer } from '../lib/cup-squad';
+import type { CupTeamVisibility } from '../lib/cup-visibility';
+import type { CupRound } from './cup-types';
+
+/** One manager's row in the cup overview for the current round. */
+export interface CupOverviewRow {
+    manager: ManagerId;
+    userName: string;
+    teamName: string;
+    division: DivisionId;
+    visibility: CupTeamVisibility;
+    /** Player codes — only populated when the team is revealed. */
+    players: number[] | null;
+    points: number | null;
+}
+
+export interface CupPageData {
+    hasConfig: boolean;
+    round: CupRound | null;
+    gameweek: number;
+    deadlinePassed: boolean;
+    rows: CupOverviewRow[];
+}
+
+export interface CupSubmitPageData {
+    hasConfig: boolean;
+    round: CupRound | null;
+    selectedUserId: string | null;
+    selectedUserName: string | null;
+    division: DivisionId | null;
+    squad: CupSquadPlayer[];
+    existingPlayers: number[];
+    /** Players used in the other leg of this round (cannot be reused). */
+    usedPlayers: number[];
+    submissionOpen: boolean;
+    deadline: string | null;
+}

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -2,6 +2,7 @@
 
 import type { DivisionId, ManagerId } from '../../teams/types/team-types';
 import type { CupSquadPlayer } from '../lib/cup-squad';
+import type { CupStanding } from '../lib/cup-standings';
 import type { CupTeamVisibility } from '../lib/cup-visibility';
 import type { CupRound } from './cup-types';
 
@@ -17,12 +18,21 @@ export interface CupOverviewRow {
     points: number | null;
 }
 
+/** A qualifier for the knockout stage — a manager and their league rank. */
+export interface CupQualifier {
+    manager: ManagerId;
+    userName: string;
+    rank: number;
+}
+
 export interface CupPageData {
     hasConfig: boolean;
     round: CupRound | null;
     gameweek: number;
     deadlinePassed: boolean;
     rows: CupOverviewRow[];
+    standings: CupStanding[];
+    qualifiers: CupQualifier[];
 }
 
 export interface CupSubmitPageData {

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -1,6 +1,7 @@
 /* Location: app/cup/types/cup-page-types.ts */
 
-import type { DivisionId, ManagerId } from '../../teams/types/team-types';
+import type { DivisionId, ManagerId, UserTeamsSheetData } from '../../teams/types/team-types';
+import type { CupFixture } from '../lib/cup-fixtures';
 import type { CupSquadPlayer } from '../lib/cup-squad';
 import type { CupStanding } from '../lib/cup-standings';
 import type { CupTeamVisibility } from '../lib/cup-visibility';
@@ -43,6 +44,11 @@ export interface CupPageData {
     /** The gameweek being viewed, and all selectable cup gameweeks. */
     selectedGameweek: number;
     gameweekOptions: CupGameweekOption[];
+    /** Real-world fixtures for the viewed gameweek. */
+    fixtures: CupFixture[];
+    /** Manager selection (shared cup header). */
+    userTeams: UserTeamsSheetData[];
+    selectedUserId: string | null;
 }
 
 export interface CupAdminPageData {
@@ -54,6 +60,7 @@ export interface CupAdminPageData {
 export interface CupSubmitPageData {
     hasConfig: boolean;
     round: CupRound | null;
+    userTeams: UserTeamsSheetData[];
     selectedUserId: string | null;
     selectedUserName: string | null;
     division: DivisionId | null;

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -70,4 +70,7 @@ export interface CupSubmitPageData {
     usedPlayers: number[];
     submissionOpen: boolean;
     deadline: string | null;
+    /** The gameweek being submitted for, and all selectable cup gameweeks. */
+    selectedGameweek: number;
+    gameweekOptions: CupGameweekOption[];
 }

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -25,6 +25,12 @@ export interface CupQualifier {
     rank: number;
 }
 
+/** An option in the cup gameweek selector. */
+export interface CupGameweekOption {
+    gameweek: number;
+    label: string;
+}
+
 export interface CupPageData {
     hasConfig: boolean;
     round: CupRound | null;
@@ -34,6 +40,9 @@ export interface CupPageData {
     standings: CupStanding[];
     qualifiers: CupQualifier[];
     bracket: CupMatchup[];
+    /** The gameweek being viewed, and all selectable cup gameweeks. */
+    selectedGameweek: number;
+    gameweekOptions: CupGameweekOption[];
 }
 
 export interface CupAdminPageData {

--- a/draft/app/cup/types/cup-page-types.ts
+++ b/draft/app/cup/types/cup-page-types.ts
@@ -4,7 +4,7 @@ import type { DivisionId, ManagerId } from '../../teams/types/team-types';
 import type { CupSquadPlayer } from '../lib/cup-squad';
 import type { CupStanding } from '../lib/cup-standings';
 import type { CupTeamVisibility } from '../lib/cup-visibility';
-import type { CupRound } from './cup-types';
+import type { CupConfig, CupMatchup, CupRound } from './cup-types';
 
 /** One manager's row in the cup overview for the current round. */
 export interface CupOverviewRow {
@@ -33,6 +33,13 @@ export interface CupPageData {
     rows: CupOverviewRow[];
     standings: CupStanding[];
     qualifiers: CupQualifier[];
+    bracket: CupMatchup[];
+}
+
+export interface CupAdminPageData {
+    config: CupConfig | null;
+    qualifiers: CupQualifier[];
+    bracket: CupMatchup[];
 }
 
 export interface CupSubmitPageData {

--- a/draft/app/cup/types/cup-types.ts
+++ b/draft/app/cup/types/cup-types.ts
@@ -1,0 +1,110 @@
+/* Location: app/cup/types/cup-types.ts */
+/** biome-ignore-all lint/style/useNamingConvention: sheet-header property names mirror the Cup sheet columns */
+
+import type { DivisionId, ManagerId } from '../../teams/types/team-types';
+
+/**
+ * The cup runs a league stage that seeds a two-legged knockout.
+ * Stage ids are stable keys used across config, submissions and the bracket.
+ */
+export type CupStageId = 'league' | 'r16' | 'qf' | 'sf' | 'final';
+
+/**
+ * The fixed shape of a stage — how many players a manager picks and whether
+ * the tie is played over two legs. This is rules, not configuration; the
+ * gameweeks a stage is played in are configured separately (see CupConfig).
+ */
+export interface CupStageShape {
+    id: CupStageId;
+    label: string;
+    playersRequired: number;
+    twoLegged: boolean;
+}
+
+/**
+ * Admin-configured mapping of cup stages to FPL gameweek ids. This is the
+ * single source of truth for "which gameweek is which stage" and everything
+ * else (deadlines, submission windows, visibility, scoring) derives from it.
+ * Stored in the Cup config sheet and edited from the admin panel.
+ */
+export interface CupConfig {
+    season: string;
+    league: number[]; // league-stage gameweek ids, in order
+    r16: [number, number]; // [leg 1 gameweek, leg 2 gameweek]
+    qf: [number, number];
+    sf: [number, number];
+    final: number; // single-leg gameweek
+}
+
+/**
+ * A resolved (stage, leg) unit mapped to a concrete FPL gameweek — the
+ * flattened form of CupConfig used by loaders and the submission UI.
+ */
+export interface CupRound {
+    stage: CupStageId;
+    leg: number; // 1-based; always 1 for single-leg stages
+    gameweek: number; // FPL gameweek id
+    playersRequired: number;
+    twoLegged: boolean;
+}
+
+/**
+ * Confirmation state of a submission. A team is only revealed publicly once
+ * its subs are CONFIRMED (mirrors the transfer approval flow), never while
+ * PENDING — even after the deadline has passed.
+ */
+export type CupSubmissionStatus = 'PENDING' | 'CONFIRMED' | 'REJECTED';
+
+/** Raw Cup submissions sheet row (header text -> cell value). */
+export interface CupSheetData {
+    Status: string; // '' = pending, 'Y' = confirmed, 'N' = rejected
+    Timestamp: string | number | Date;
+    Manager: string;
+    Division: string;
+    Gameweek: string | number;
+    Stage: string;
+    Leg: string | number;
+    Players: string; // comma-separated player codes
+    SubmittedByAdmin: string | boolean;
+    AdminReason: string;
+}
+
+/** Normalised sheet row after parsing/transform. */
+export interface ProcessedCupSheetData {
+    status: string;
+    timestamp: Date;
+    manager: ManagerId;
+    division: DivisionId;
+    gameweek: number;
+    stage: CupStageId;
+    leg: number;
+    players: number[];
+    submittedByAdmin: boolean;
+    adminReason: string;
+}
+
+/** A manager's team submission for one cup round (one gameweek/leg). */
+export interface CupSubmission {
+    id: string;
+    manager: ManagerId;
+    division: DivisionId;
+    gameweek: number;
+    stage: CupStageId;
+    leg: number;
+    players: number[]; // player codes
+    submittedByAdmin: boolean;
+    adminReason?: string;
+    status: CupSubmissionStatus;
+    timestamp: Date;
+}
+
+/** A single knockout tie within a stage. */
+export interface CupMatchup {
+    stage: CupStageId;
+    tie: number; // index of the tie within the stage
+    home: ManagerId | null;
+    away: ManagerId | null;
+    homeAggregate?: number;
+    awayAggregate?: number;
+    winner?: ManagerId | null;
+}

--- a/draft/app/root.tsx
+++ b/draft/app/root.tsx
@@ -131,6 +131,7 @@ const navigationItems = [
     { href: '/teams?tab=all-teams', label: 'Teams' },
     { href: '/players', label: 'Players' },
     { href: '/transfers', label: 'Transfers' },
+    { href: '/cup', label: 'Cup' },
     { href: '/wishlists', label: 'Wishlists' },
     { href: '/draft', label: 'Draft' },
 ];

--- a/draft/app/routes.ts
+++ b/draft/app/routes.ts
@@ -16,6 +16,10 @@ export default [
     route('transfers/:divisionId?', 'transfers/transfers.route.tsx'),
     route('wishlists', 'wishlist/wishlists.route.tsx'),
 
+    // Cup (cross-division knockout)
+    route('cup', 'cup/cup.route.tsx'),
+    route('cup/submit', 'cup/cup-submit.route.tsx'),
+
     route('scoring/api/gw-points', 'scoring/api/api.gw-points.ts'),
 
     // NEW: Fresh transfers API for client-side fetching

--- a/draft/app/routes.ts
+++ b/draft/app/routes.ts
@@ -19,6 +19,7 @@ export default [
     // Cup (cross-division knockout)
     route('cup', 'cup/cup.route.tsx'),
     route('cup/submit', 'cup/cup-submit.route.tsx'),
+    route('cup/admin', 'cup/cup-admin.route.tsx'),
 
     route('scoring/api/gw-points', 'scoring/api/api.gw-points.ts'),
 


### PR DESCRIPTION
## Cup feature (cross-division knockout)

Adds a full **Cup** feature — league stage → two-legged knockout (R16 → QF → SF → Final) → winner — rebuilt natively in the current stack (React Router v7 SSR, Google Sheets, Firestore, CSS Modules). It mirrors the `transfers` domain's conventions throughout.

### What's included
- **`/cup`** — cross-division overview with a **round selector** (view any cup gameweek), real **fixtures** for the gameweek, league-stage standings + **top-16 qualifiers**, and a **per-stage head-to-head matchups view** for knockout rounds (leg points + aggregate, winner highlighted).
- **`/cup/submit`** — squad selector reusing the roster + user-selection, **deadline lockout**, hide-until-(deadline + subs confirmed) visibility, cross-leg player-reuse prevention, client cap + **server-side re-validation**.
- **`/cup/admin`** — set the **stage→gameweek mapping** (propagates cup-wide) and generate the random **R16 draw**.
- **Scoring** reuses the site's existing per-player league points (`player-gw-points`) — no recomputation, no double counting.
- **Data** lives in Google Sheets: `Cup` (submissions), `CupConfig` (stage→gameweek), `CupBracket` (draw), all cross-division. Cache keys + invalidation added to `cache-config.ts`.

### Conventions
Vertical slice under `draft/app/cup/` (types/lib/components/server), CSS Modules with design tokens, loaders/actions delegating to `server/`, Sheets header-maps like `transfers.ts`, Biome-clean.

### Included bug fix (outside the cup domain)
`readPlayerGameweekPointsFromSheet` re-read `readDataFromSheetWithHeaders` output as raw arrays when it already returns header-keyed objects — so it returned empty `playerCode`s and `0` points. This zeroed cup scoring **and** affects the existing `scoring/api/gw-points` route. Fixed to consume the parsed objects (+ regression test).

### Testing
55 co-located unit tests over the pure rules (config, deadlines/visibility, squad, submission validation, scoring, standings, knockout, matchups, fixtures, autopick). Verified end-to-end live against production data (submission write, deadline lockout, matchups with points matching the sheet exactly).

### Known follow-ups (not blocking)
- Wire pending-sub projection/badges (helper ready; loader passes none yet).
- Admin actions for autopick + tie resolution/advancement (pure logic tested, not yet behind buttons).
- Admin manual submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
