### PR TITLE
Fix defensive-contribution scoring for custom-vs-FPL position mismatches

### DIFF
--- a/draft/app/_shared/lib/fpl/fpl-types.ts
+++ b/draft/app/_shared/lib/fpl/fpl-types.ts
@@ -48,6 +48,9 @@ export interface FplPlayerData {
     red_cards: number;
     saves: number;
     bonus: number;
+    clearances_blocks_interceptions: number;
+    tackles: number;
+    recoveries: number;
     defensive_contribution: number;
     bps: number;
     starts: number;
@@ -79,6 +82,9 @@ export interface FplPlayerGameweekData {
     red_cards: number;
     saves: number;
     bonus: number;
+    clearances_blocks_interceptions: number;
+    tackles: number;
+    recoveries: number;
     defensive_contribution: number;
     bps: number;
     influence: string;

--- a/draft/app/_shared/lib/roster-conversion-utils.ts
+++ b/draft/app/_shared/lib/roster-conversion-utils.ts
@@ -146,6 +146,9 @@ export function createEmptyStats(): PlayerGameweekStatsData {
         redCards: 0,
         saves: 0,
         defensiveContribution: 0,
+        clearancesBlocksInterceptions: 0,
+        tackles: 0,
+        recoveries: 0,
         bonus: 0,
     };
 }

--- a/draft/app/players/server/player.server.ts
+++ b/draft/app/players/server/player.server.ts
@@ -129,6 +129,9 @@ function processGameweekData(fplHistory: any[], teamLookup: Record<number, any>)
             // FPL points
             fplPoints: gwData.total_points,
             defensiveContribution: gwData.defensive_contribution,
+            clearancesBlocksInterceptions: gwData.clearances_blocks_interceptions ?? 0,
+            tackles: gwData.tackles ?? 0,
+            recoveries: gwData.recoveries ?? 0,
 
             // Metadata
             generatedAt: null,

--- a/draft/app/players/server/players.server.ts
+++ b/draft/app/players/server/players.server.ts
@@ -101,6 +101,9 @@ export async function getPlayerStatsForGameweek(gameweek: number): Promise<Playe
                     saves: 0,
                     bonus: 0,
                     defensiveContribution: 0,
+                    clearancesBlocksInterceptions: 0,
+                    tackles: 0,
+                    recoveries: 0,
                 };
                 const { points, stats } = calculateSeasonPoints([zeroStats], position);
                 const fullBreakdown = getFullBreakdown([zeroStats], position, { points, stats });

--- a/draft/app/players/types/player-types.ts
+++ b/draft/app/players/types/player-types.ts
@@ -28,6 +28,12 @@ export interface PlayerGameweekStatsData {
     saves: number;
     bonus: number;
     defensiveContribution: number;
+    // Raw components behind the defensive-contribution metric. We compute CBIT/CBIRT
+    // ourselves (by custom position) rather than trusting FPL's aggregate, which is
+    // baked to FPL's own position.
+    clearancesBlocksInterceptions: number;
+    tackles: number;
+    recoveries: number;
 }
 
 export interface PlayerDetailData {

--- a/draft/app/scoring/lib/calculations.test.ts
+++ b/draft/app/scoring/lib/calculations.test.ts
@@ -1,5 +1,56 @@
 import { describe, expect, it } from 'vitest';
-import { calculateBonus, calculateGoalsConcededPenalty, calculateSavesBonus } from './calculations';
+import {
+    calculateBonus,
+    calculateDefensiveContribution,
+    calculateGoalsConcededPenalty,
+    calculateSavesBonus,
+} from './calculations';
+
+// ---------------------------------------------------------------------------
+// calculateDefensiveContribution
+// ---------------------------------------------------------------------------
+
+// We compute CBIT/CBIRT ourselves from the raw components and key the metric off OUR
+// custom position: defenders (cb/fb) use CBIT (10+ = +1, recoveries excluded);
+// midfielders (mid) use CBIRT (12+ = +2, recoveries included). This must NOT rely on
+// FPL's aggregate, which bakes in FPL's own position.
+const raw = (clearancesBlocksInterceptions: number, tackles: number, recoveries: number) => ({
+    clearancesBlocksInterceptions,
+    tackles,
+    recoveries,
+});
+
+describe('calculateDefensiveContribution', () => {
+    it('awards a defender (cb/fb) +1 when CBIT reaches 10, excluding recoveries', () => {
+        expect(calculateDefensiveContribution(raw(6, 4, 0), 'cb')).toBe(1); // 10 CBIT
+        expect(calculateDefensiveContribution(raw(6, 4, 9), 'fb')).toBe(1); // recoveries irrelevant
+    });
+
+    it('does NOT count recoveries for a defender (CBIT below 10 stays 0 despite recoveries)', () => {
+        // 8 CBIT + 5 recoveries — recoveries must be ignored for defenders, so still < 10
+        expect(calculateDefensiveContribution(raw(4, 4, 5), 'cb')).toBe(0);
+    });
+
+    it('awards a midfielder +2 when CBIRT reaches 12, including recoveries', () => {
+        expect(calculateDefensiveContribution(raw(5, 3, 4), 'mid')).toBe(2); // 8 CBIT + 4 rec = 12
+    });
+
+    it('the Matheus Nunes case: mid-by-us gets recoveries counted (FPL would treat him as a defender)', () => {
+        // 8 CBIT + 5 recoveries = 13 CBIRT >= 12 → +2. FPL's aggregate (CBIT only, no recoveries)
+        // would be 8 and wrongly miss the threshold.
+        expect(calculateDefensiveContribution(raw(5, 3, 5), 'mid')).toBe(2);
+    });
+
+    it('returns 0 for a midfielder below the CBIRT threshold', () => {
+        expect(calculateDefensiveContribution(raw(4, 3, 2), 'mid')).toBe(0); // 9 CBIRT < 12
+    });
+
+    it('returns 0 for positions with no defensive-contribution rule (gk, wa, ca)', () => {
+        expect(calculateDefensiveContribution(raw(20, 20, 20), 'gk')).toBe(0);
+        expect(calculateDefensiveContribution(raw(20, 20, 20), 'wa')).toBe(0);
+        expect(calculateDefensiveContribution(raw(20, 20, 20), 'ca')).toBe(0);
+    });
+});
 
 // ---------------------------------------------------------------------------
 // calculateGoalsConcededPenalty

--- a/draft/app/scoring/lib/calculations.test.ts
+++ b/draft/app/scoring/lib/calculations.test.ts
@@ -21,28 +21,37 @@ const raw = (clearancesBlocksInterceptions: number, tackles: number, recoveries:
 });
 
 describe('calculateDefensiveContribution', () => {
-    it('awards a defender (cb/fb) +1 when CBIT reaches 10, excluding recoveries', () => {
-        expect(calculateDefensiveContribution(raw(6, 4, 0), 'cb')).toBe(1); // 10 CBIT
-        expect(calculateDefensiveContribution(raw(6, 4, 9), 'fb')).toBe(1); // recoveries irrelevant
+    // Same input, only the position changes: isolates that CB/FB use CBIT vs a
+    // threshold of 10 while MID uses CBIRT vs 12. raw(6,4,0) is 10 CBIT / 10 CBIRT.
+    it('scores the same input differently by position (10 CBIT/CBIRT, no recoveries)', () => {
+        expect(calculateDefensiveContribution(raw(6, 4, 0), 'cb')).toBe(1); // 10 >= 10
+        expect(calculateDefensiveContribution(raw(6, 4, 0), 'fb')).toBe(1); // 10 >= 10
+        expect(calculateDefensiveContribution(raw(6, 4, 0), 'mid')).toBe(0); // 10 < 12
+        expect(calculateDefensiveContribution(raw(6, 4, 0), 'gk')).toBe(0); // no rule
     });
 
-    it('does NOT count recoveries for a defender (CBIT below 10 stays 0 despite recoveries)', () => {
-        // 8 CBIT + 5 recoveries — recoveries must be ignored for defenders, so still < 10
-        expect(calculateDefensiveContribution(raw(4, 4, 5), 'cb')).toBe(0);
+    // Defender boundary: only CBIT changes (recoveries fixed at 0).
+    it('awards a defender +1 exactly at the CBIT threshold of 10, not below', () => {
+        expect(calculateDefensiveContribution(raw(5, 4, 0), 'fb')).toBe(0); // 9
+        expect(calculateDefensiveContribution(raw(5, 5, 0), 'fb')).toBe(1); // 10
+        expect(calculateDefensiveContribution(raw(5, 5, 0), 'cb')).toBe(1); // 10
     });
 
-    it('awards a midfielder +2 when CBIRT reaches 12, including recoveries', () => {
-        expect(calculateDefensiveContribution(raw(5, 3, 4), 'mid')).toBe(2); // 8 CBIT + 4 rec = 12
+    // Counter-case: recoveries must NOT lift a defender over the line.
+    it('ignores recoveries for a defender (9 CBIT + 9 recoveries stays 0)', () => {
+        expect(calculateDefensiveContribution(raw(5, 4, 9), 'fb')).toBe(0); // CBIT 9, recoveries ignored
     });
 
-    it('the Matheus Nunes case: mid-by-us gets recoveries counted (FPL would treat him as a defender)', () => {
-        // 8 CBIT + 5 recoveries = 13 CBIRT >= 12 → +2. FPL's aggregate (CBIT only, no recoveries)
-        // would be 8 and wrongly miss the threshold.
-        expect(calculateDefensiveContribution(raw(5, 3, 5), 'mid')).toBe(2);
+    // Midfielder boundary: only CBIRT changes.
+    it('awards a midfielder +2 exactly at the CBIRT threshold of 12, not below', () => {
+        expect(calculateDefensiveContribution(raw(6, 5, 0), 'mid')).toBe(0); // 11
+        expect(calculateDefensiveContribution(raw(6, 5, 1), 'mid')).toBe(2); // 12
     });
 
-    it('returns 0 for a midfielder below the CBIRT threshold', () => {
-        expect(calculateDefensiveContribution(raw(4, 3, 2), 'mid')).toBe(0); // 9 CBIRT < 12
+    // Counter-case: for a midfielder ONLY recoveries change, proving they count.
+    it('counts recoveries for a midfielder (the Matheus Nunes case)', () => {
+        expect(calculateDefensiveContribution(raw(6, 4, 1), 'mid')).toBe(0); // 10 CBIT + 1 = 11 < 12
+        expect(calculateDefensiveContribution(raw(6, 4, 2), 'mid')).toBe(2); // 10 CBIT + 2 = 12
     });
 
     it('returns 0 for positions with no defensive-contribution rule (gk, wa, ca)', () => {

--- a/draft/app/scoring/lib/calculations.ts
+++ b/draft/app/scoring/lib/calculations.ts
@@ -20,14 +20,28 @@ const baselineStats: Points = {
     total: 0,
 };
 
+// Positions that count recoveries towards their defensive-contribution total (CBIRT),
+// mirroring FPL's midfielder/forward rule. Defenders (cb/fb) use CBIT only.
+const RECOVERIES_COUNT_FOR: CustomPosition[] = ['mid', 'wa', 'ca'];
+
 /**
- * Calculate appearance points based on minutes played
+ * Calculate defensive-contribution points from the raw components, using OUR custom
+ * position to decide the metric — CBIT (clearances+blocks+interceptions+tackles) for
+ * defenders, CBIRT (+ recoveries) for midfielders/attackers. We do NOT use FPL's
+ * aggregate `defensive_contribution`, which bakes in FPL's own position and is wrong
+ * whenever our position disagrees with FPL's (e.g. Matheus Nunes).
  */
-export function calculateDefensiveContribution(defensiveContribution: number, position: CustomPosition): number {
+export function calculateDefensiveContribution(
+    stats: Pick<PlayerGameweekStatsData, 'clearancesBlocksInterceptions' | 'tackles' | 'recoveries'>,
+    position: CustomPosition,
+): number {
     const rule = POSITION_RULES[position];
     if (!('defensiveContribution' in rule)) return 0;
 
-    if ((defensiveContribution || 0) < rule.defensiveContribution.threshold) return 0;
+    const cbit = (stats.clearancesBlocksInterceptions || 0) + (stats.tackles || 0);
+    const total = RECOVERIES_COUNT_FOR.includes(position) ? cbit + (stats.recoveries || 0) : cbit;
+
+    if (total < rule.defensiveContribution.threshold) return 0;
     return rule.defensiveContribution.points;
 }
 /**
@@ -141,8 +155,7 @@ export function calculateGameweekPoints(gws: PlayerGameweekStatsData[], position
                 penaltiesSaved: acc.penaltiesSaved + calculatePenaltiesSaved(stats.penaltiesSaved, position),
                 goalsConceded: acc.goalsConceded + calculateGoalsConcededPenalty(stats.goalsConceded, position),
                 bonus: acc.bonus + calculateBonus(stats.bonus, position),
-                defensiveContribution:
-                    acc.defensiveContribution + calculateDefensiveContribution(stats.defensiveContribution, position),
+                defensiveContribution: acc.defensiveContribution + calculateDefensiveContribution(stats, position),
                 total: 0,
             };
 

--- a/draft/app/scoring/lib/calculations.ts
+++ b/draft/app/scoring/lib/calculations.ts
@@ -20,16 +20,15 @@ const baselineStats: Points = {
     total: 0,
 };
 
-// Positions that count recoveries towards their defensive-contribution total (CBIRT),
-// mirroring FPL's midfielder/forward rule. Defenders (cb/fb) use CBIT only.
-const RECOVERIES_COUNT_FOR: CustomPosition[] = ['mid', 'wa', 'ca'];
-
 /**
  * Calculate defensive-contribution points from the raw components, using OUR custom
- * position to decide the metric — CBIT (clearances+blocks+interceptions+tackles) for
- * defenders, CBIRT (+ recoveries) for midfielders/attackers. We do NOT use FPL's
- * aggregate `defensive_contribution`, which bakes in FPL's own position and is wrong
- * whenever our position disagrees with FPL's (e.g. Matheus Nunes).
+ * position to decide the metric: CBIT (clearances+blocks+interceptions+tackles) for
+ * defenders, CBIRT (+ recoveries) for midfielders. We do NOT use FPL's aggregate
+ * `defensive_contribution`, which bakes in FPL's own position and is wrong whenever
+ * our position disagrees with FPL's (e.g. Matheus Nunes).
+ *
+ * Only cb, fb and mid have a defensive-contribution rule, so mid is the only position
+ * that counts recoveries. If wa/ca ever gain a rule, revisit whether they should too.
  */
 export function calculateDefensiveContribution(
     stats: Pick<PlayerGameweekStatsData, 'clearancesBlocksInterceptions' | 'tackles' | 'recoveries'>,
@@ -39,7 +38,7 @@ export function calculateDefensiveContribution(
     if (!('defensiveContribution' in rule)) return 0;
 
     const cbit = (stats.clearancesBlocksInterceptions || 0) + (stats.tackles || 0);
-    const total = RECOVERIES_COUNT_FOR.includes(position) ? cbit + (stats.recoveries || 0) : cbit;
+    const total = position === 'mid' ? cbit + (stats.recoveries || 0) : cbit;
 
     if (total < rule.defensiveContribution.threshold) return 0;
     return rule.defensiveContribution.points;

--- a/draft/app/scoring/lib/data-conversion.ts
+++ b/draft/app/scoring/lib/data-conversion.ts
@@ -20,6 +20,9 @@ export function convertToSingleGameweeksStats(gameweekData: PlayerGameweekStatsD
             saves: acc.saves + curr.saves,
             penaltiesSaved: acc.penaltiesSaved + curr.penaltiesSaved,
             defensiveContribution: acc.defensiveContribution + curr.defensiveContribution,
+            clearancesBlocksInterceptions: acc.clearancesBlocksInterceptions + curr.clearancesBlocksInterceptions,
+            tackles: acc.tackles + curr.tackles,
+            recoveries: acc.recoveries + curr.recoveries,
             bonus: acc.bonus + curr.bonus,
         }),
         {
@@ -33,6 +36,9 @@ export function convertToSingleGameweeksStats(gameweekData: PlayerGameweekStatsD
             saves: 0,
             penaltiesSaved: 0,
             defensiveContribution: 0,
+            clearancesBlocksInterceptions: 0,
+            tackles: 0,
+            recoveries: 0,
             bonus: 0,
         },
     );
@@ -61,6 +67,9 @@ export function convertToPlayerGameweekStats(gw: FplPlayerGameweekData): PlayerG
         penaltiesSaved: gw.penalties_saved,
         bonus: gw.bonus,
         defensiveContribution: gw.defensive_contribution,
+        clearancesBlocksInterceptions: gw.clearances_blocks_interceptions,
+        tackles: gw.tackles,
+        recoveries: gw.recoveries,
     };
 }
 /**
@@ -79,5 +88,8 @@ export function convertToGameweekStats(gw: GameweekStatWithPoints): PlayerGamewe
         penaltiesSaved: gw.penaltiesSaved,
         bonus: gw.bonus,
         defensiveContribution: gw.defensiveContribution,
+        clearancesBlocksInterceptions: gw.clearancesBlocksInterceptions,
+        tackles: gw.tackles,
+        recoveries: gw.recoveries,
     };
 }

--- a/draft/app/scoring/server/services/division-teams-points-population.service.ts
+++ b/draft/app/scoring/server/services/division-teams-points-population.service.ts
@@ -32,7 +32,9 @@ export async function calculateSingleTeamPoints({
     try {
         for (const [slotKey, { player }] of Object.entries(teamData.roster)) {
             if (!player?.playerId) {
-                throw new Error(`Missing playerId in slot '${slotKey}' for user '${userId}' in division '${divisionDoc.divisionId}' GW${gameweek}`);
+                throw new Error(
+                    `Missing playerId in slot '${slotKey}' for user '${userId}' in division '${divisionDoc.divisionId}' GW${gameweek}`,
+                );
             }
         }
         const rosterPlayers = Object.values(teamData.roster).map(({ player }) => player);
@@ -294,6 +296,10 @@ function addStatsToSeason(
         saves: seasonStats.saves + gameweekStats.saves,
         bonus: seasonStats.bonus + gameweekStats.bonus,
         defensiveContribution: seasonStats.defensiveContribution + gameweekStats.defensiveContribution,
+        clearancesBlocksInterceptions:
+            seasonStats.clearancesBlocksInterceptions + gameweekStats.clearancesBlocksInterceptions,
+        tackles: seasonStats.tackles + gameweekStats.tackles,
+        recoveries: seasonStats.recoveries + gameweekStats.recoveries,
     };
 }
 
@@ -339,6 +345,9 @@ function createEmptyStats(): PlayerGameweekStatsData {
         redCards: 0,
         saves: 0,
         defensiveContribution: 0,
+        clearancesBlocksInterceptions: 0,
+        tackles: 0,
+        recoveries: 0,
         bonus: 0,
     };
 }

--- a/draft/app/scoring/types/scoring-types.ts
+++ b/draft/app/scoring/types/scoring-types.ts
@@ -35,6 +35,9 @@ export interface GameweekStatWithPoints {
     penaltiesSaved: number;
     bonus: number;
     defensiveContribution: number;
+    clearancesBlocksInterceptions: number;
+    tackles: number;
+    recoveries: number;
 
     // Match info
     opponent: number;

--- a/draft/app/transfers/lib/transfer-processor.service.ts
+++ b/draft/app/transfers/lib/transfer-processor.service.ts
@@ -291,6 +291,10 @@ function createEmptyStats(): PlayerGameweekStatsData {
         redCards: 0,
         saves: 0,
         bonus: 0,
+        defensiveContribution: 0,
+        clearancesBlocksInterceptions: 0,
+        tackles: 0,
+        recoveries: 0,
     };
 }
 


### PR DESCRIPTION
## Fix defensive-contribution scoring for position mismatches

### The bug
Kammy scored defensive contribution off FPL's aggregated `defensive_contribution` field. But FPL computes that number using **its own** position: recoveries are **included** for FPL midfielders/forwards and **excluded** for FPL defenders. Kammy then applied a threshold chosen by **our custom** position — so whenever the two position systems disagree, the recoveries end up on the wrong side of the calculation.

Verified against live FPL data — the field is CBI+tackles for FPL defenders and CBI+tackles+**recoveries** for FPL mids/fwds:
```
DEF Gabriel  DC 277 = CBI+TK (no recoveries)
MID Saka     DC 184 = CBI+TK+REC  (68 without recoveries)
```

### Impact (e.g. Matheus Nunes — mid by us, defender by FPL)
- FPL's field excludes recoveries; our **MID** rule expects CBIRT (with recoveries) vs a threshold of 12 → he was **under-credited** and missed points he should earn.
- The mirror case (our cb/fb, FPL mid) **over-credited**.

### The fix
The raw components (`clearances_blocks_interceptions`, `tackles`, `recoveries`) are already in the FPL API responses we fetch — we just weren't mapping them. This PR:
1. Carries those raw fields through `FplPlayerGameweekData` → `PlayerGameweekStatsData` / `GameweekStatWithPoints` and the data converters.
2. Computes **CBIT** (cb/fb) or **CBIRT** (mid, + recoveries) in `calculateDefensiveContribution`, keyed off **our custom position** — no longer trusting FPL's aggregate.

This mirrors the reference (Lovable) calculation and flows through the `player-gw-points` sheet, team/league scoring, and the cup.

### Notes
- No new typecheck errors (also fixes one pre-existing missing-field error in a `createEmptyStats` factory).
- 89 tests pass, including new coverage for **both** position-mismatch directions and the "recoveries excluded for defenders / included for mids" rule.
- Regenerating `player-gw-points` (admin) applies the corrected values to existing gameweeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
