### PR TITLE
Improve transfer selector mobile layout and journey UX

### DIFF
--- a/draft/app/_shared/components/table.module.css
+++ b/draft/app/_shared/components/table.module.css
@@ -419,25 +419,27 @@
 }
 
 .tableWrapper::-webkit-scrollbar-thumb {
-    background: var(--color-gray-300);
+    background: var(--color-gray-400);
     border-radius: var(--radius-sm);
 }
 
 .tableWrapper::-webkit-scrollbar-thumb:hover {
-    background: var(--color-gray-400);
+    background: var(--color-gray-500);
 }
 
 /* Fixed column support */
 .fixedColumn {
     position: sticky;
     left: 0;
-    background-color: inherit;
-    z-index: 5; /* Ensure fixed column has shadow to show it's floating */
+    /* Opaque bg so scrolled cells don't show through sticky identity column */
+    background-color: var(--color-white);
+    z-index: 5;
     box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
 }
 
 th.fixedColumn {
     z-index: 15;
+    background-color: var(--table-header-bg);
 }
 
 .fixedColumn::after {

--- a/draft/app/transfers/components/player-in-selector.module.css
+++ b/draft/app/transfers/components/player-in-selector.module.css
@@ -21,28 +21,52 @@
     border-radius: var(--radius-md);
     margin-bottom: var(--spacing-4);
     border: 1px solid var(--color-info-border);
+    flex-shrink: 0;
 }
 
 .contextIcon {
     font-size: var(--font-lg);
+    flex-shrink: 0;
+    line-height: 1;
 }
 
 .contextText {
     color: var(--color-info);
     font-size: var(--font-sm);
     font-weight: var(--font-weight-medium);
+    line-height: 1.3;
 }
 
 .filters {
     display: flex;
     gap: var(--spacing-3);
-    margin-bottom: var(--spacing-4);
+    margin-bottom: var(--spacing-3);
     flex-wrap: wrap;
+    align-items: flex-end;
+    flex-shrink: 0;
+}
+
+.filterGroup {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+    flex: 1 1 8rem;
+    min-width: 8rem;
+}
+
+.filterLabel {
+    font-size: var(--font-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-600);
+}
+
+.multiSelect {
+    width: 100%;
 }
 
 .searchInput {
-    flex: 1;
-    min-width: 200px;
+    flex: 1 1 12rem;
+    min-width: 12rem;
     padding: var(--spacing-2) var(--spacing-3);
     border: 1px solid var(--color-gray-300);
     border-radius: var(--radius-md);
@@ -83,9 +107,23 @@
     height: 16px;
 }
 
+.resultsCount {
+    font-size: var(--font-sm);
+    color: var(--color-gray-600);
+    margin-bottom: var(--spacing-2);
+    flex-shrink: 0;
+}
+
+.filterInfo {
+    color: var(--color-gray-500);
+}
+
 .playerList {
-    max-height: 400px;
+    flex: 1;
+    overflow-x: hidden;
     overflow-y: auto;
+    max-height: min(60dvh, 28rem);
+    min-height: 0;
     border: 1px solid var(--color-gray-200);
     border-radius: var(--radius-md);
     background: var(--color-white);
@@ -98,6 +136,20 @@
     min-height: 0;
     margin-bottom: 0;
     height: 100%;
+    gap: var(--spacing-2);
+}
+
+.embeddedInJourney .transferContext {
+    margin-bottom: 0;
+    padding: var(--spacing-2) var(--spacing-3);
+}
+
+.embeddedInJourney .filters {
+    margin-bottom: 0;
+}
+
+.embeddedInJourney .resultsCount {
+    margin-bottom: 0;
 }
 
 .embeddedInJourney .playerList {
@@ -110,18 +162,29 @@
     border-bottom: 1px solid var(--color-gray-100);
     cursor: pointer;
     transition: background-color var(--transition-normal);
+    background-color: var(--color-white);
 }
 
 .playerCard:last-child {
     border-bottom: none;
 }
 
-.playerCard:hover {
-    background: var(--color-gray-50);
+.playerCard:nth-child(even) {
+    background-color: var(--color-gray-50);
 }
 
-.playerCard.selected {
-    background: var(--color-primary-light);
+.playerCard:nth-child(even) td {
+    background-color: var(--color-gray-50);
+}
+
+.playerCard:hover,
+.playerCard:hover td {
+    background-color: var(--color-gray-100);
+}
+
+.playerCard.selected,
+.playerCard.selected td {
+    background-color: var(--color-primary-light);
     border-color: var(--color-primary);
 }
 
@@ -130,8 +193,14 @@
     cursor: not-allowed;
 }
 
-.playerCard.ineligible:hover {
-    background: var(--color-white);
+.playerCard.ineligible:hover,
+.playerCard.ineligible:hover td {
+    background-color: var(--color-white);
+}
+
+.playerCard.ineligible:nth-child(even):hover,
+.playerCard.ineligible:nth-child(even):hover td {
+    background-color: var(--color-gray-50);
 }
 
 .playerInfo {
@@ -198,24 +267,37 @@
 }
 
 /* Responsive adjustments */
-@media (max-width: var(--breakpoint-md)) {
-    .filters {
-        flex-direction: column;
-    }
-
-    .searchInput {
-        min-width: auto;
-    }
-
-    .playerCard {
-        flex-direction: column;
-        align-items: flex-start;
+@media (max-width: 768px) {
+    .transferContext {
+        padding: var(--spacing-2);
+        margin-bottom: var(--spacing-2);
         gap: var(--spacing-2);
     }
 
-    .playerStatus {
-        align-self: flex-end;
-        text-align: left;
+    .contextIcon {
+        font-size: var(--font-base);
+    }
+
+    .contextText {
+        font-size: var(--font-xs);
+    }
+
+    .filters {
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--spacing-2);
+        margin-bottom: var(--spacing-2);
+    }
+
+    .searchInput,
+    .filterGroup {
+        width: 100%;
+        min-width: 0;
+        flex: none;
+    }
+
+    .selectedSummary {
+        padding: var(--spacing-3);
     }
 }
 
@@ -249,7 +331,9 @@
         display: unset;
     }
 }
+
 .selectedSummary {
+    flex-shrink: 0;
     padding: var(--spacing-3) var(--spacing-4);
     background: var(--color-primary-bg);
     border-top: 1px solid var(--color-primary);
@@ -259,6 +343,7 @@
     display: flex;
     align-items: center;
     gap: var(--spacing-2);
+    flex-wrap: wrap;
 }
 
 .summaryLabel {

--- a/draft/app/transfers/components/player-in-selector.tsx
+++ b/draft/app/transfers/components/player-in-selector.tsx
@@ -292,6 +292,7 @@ export function PlayerInSelector({
                             selectedValues={selectedStatuses}
                             onSelectionChange={onStatusChange}
                             placeholder="Player Status"
+                            className={styles.multiSelect}
                         />
                     </div>
                 )}

--- a/draft/app/transfers/components/player-out-selector.module.css
+++ b/draft/app/transfers/components/player-out-selector.module.css
@@ -59,8 +59,9 @@
 .playersList,
 .playerList {
     flex: 1;
+    overflow-x: hidden;
     overflow-y: auto;
-    max-height: 400px;
+    max-height: min(60dvh, 28rem);
     min-height: 0;
 }
 
@@ -97,20 +98,32 @@
 }
 
 .playerItem {
-    padding: var(--spacing-3) var(--spacing-4);
-    border-bottom: 1px solid var(--color-gray-200);
     cursor: pointer;
     transition: var(--transition-normal);
     position: relative;
+    background-color: var(--color-white);
 }
 
-.playerItem:hover {
-    background: var(--color-gray-50);
+.playerItem:nth-child(even) {
+    background-color: var(--color-gray-50);
+}
+
+.playerItem:nth-child(even) td {
+    background-color: var(--color-gray-50);
+}
+
+.playerItem:hover,
+.playerItem:hover td {
+    background-color: var(--color-gray-100);
 }
 
 .playerItem.selected {
-    background: var(--color-primary-light);
+    background-color: var(--color-primary-light);
     border-left: 3px solid var(--color-primary);
+}
+
+.playerItem.selected td {
+    background-color: var(--color-primary-light);
 }
 
 .playerContent {
@@ -155,6 +168,7 @@
 }
 
 .selectedSummary {
+    flex-shrink: 0;
     padding: var(--spacing-3) var(--spacing-4);
     background: var(--color-primary-bg);
     border-top: 1px solid var(--color-primary);
@@ -164,6 +178,7 @@
     display: flex;
     align-items: center;
     gap: var(--spacing-2);
+    flex-wrap: wrap;
 }
 
 .summaryLabel {
@@ -177,8 +192,19 @@
     font-weight: var(--font-weight-semibold);
     color: var(--color-gray-900);
 }
+
 .summaryDetails {
     font-size: var(--font-sm);
     font-weight: var(--font-weight-normal);
     color: var(--color-gray-700);
+}
+
+@media (max-width: 768px) {
+    .playerOutSelector {
+        gap: var(--spacing-2);
+    }
+
+    .selectedSummary {
+        padding: var(--spacing-3);
+    }
 }

--- a/draft/app/transfers/components/transfer-form.module.css
+++ b/draft/app/transfers/components/transfer-form.module.css
@@ -25,6 +25,15 @@
     margin: 0;
 }
 
+.journeyTitle:focus {
+    outline: none;
+}
+
+.journeyTitle:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
 .backButton {
     align-self: flex-start;
     background: none;
@@ -62,6 +71,8 @@
     background: var(--color-white);
     border-top: 1px solid var(--color-gray-200);
     box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.06);
+    /* Allow transfer-type menu to paint above the footer without clipping */
+    overflow: visible;
 }
 
 .inlineTransferType {

--- a/draft/app/transfers/components/transfer-form.tsx
+++ b/draft/app/transfers/components/transfer-form.tsx
@@ -1,7 +1,7 @@
 // app/transfers/components/transfer-form.tsx
 
 import type * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFetcher } from 'react-router';
 import { SelectUser } from '../../_shared/components/select-user';
 import { ToastManager, useToast } from '../../_shared/components/toast-manager';
@@ -410,7 +410,7 @@ function SelectorReview({
                     disabled={canSubmit}
                     className={`${styles.submitButton} ${isSubmitting ? styles.loading : ''}`}
                 >
-                    {isSubmitting ? 'Submitting...' : 'Submit Transfer'}
+                    {isSubmitting ? 'Submitting...' : 'Submit'}
                 </button>
             </div>
         </>
@@ -439,6 +439,16 @@ export function TransferForm({
     const [loanSelection, setLoanSelection] = useState<LoanSelectionState>(INITIAL_LOAN_SELECTION);
     const [comment, setComment] = useState('');
     const [validation, setValidation] = useState<TransferValidationResult>(INITIAL_VALIDATION);
+    const stepContentRef = useRef<HTMLDivElement>(null);
+    const journeyTitleRef = useRef<HTMLHeadingElement>(null);
+
+    // Keep each step starting at the top after Continue/Back (window + step panel scroll;
+    // also moves focus off the footer button so the browser does not keep it in view).
+    useEffect(() => {
+        window.scrollTo(0, 0);
+        stepContentRef.current?.scrollTo(0, 0);
+        journeyTitleRef.current?.focus({ preventScroll: true });
+    }, [step]);
 
     const playersByCode: Record<number, EnhancedPlayerData> = Object.fromEntries(
         availablePlayers.map((player) => [player.code, player]),
@@ -596,12 +606,14 @@ export function TransferForm({
                 <button type="button" className={styles.backButton} onClick={goBack}>
                     ← {step === JOURNEY_STEPS.firstSelector ? 'Back to hub' : 'Back'}
                 </button>
-                <h2 className={styles.journeyTitle}>{STEP_TITLES[step][journeyPath]}</h2>
+                <h2 className={styles.journeyTitle} ref={journeyTitleRef} tabIndex={-1}>
+                    {STEP_TITLES[step][journeyPath]}
+                </h2>
             </div>
 
             <form onSubmit={handleSubmit} className={styles.form}>
                 {step === JOURNEY_STEPS.firstSelector ? (
-                    <div className={styles.stepContent}>
+                    <div className={styles.stepContent} ref={stepContentRef}>
                         <FirstSelector
                             availablePlayers={availablePlayers}
                             selectedManager={selectedManager}
@@ -620,7 +632,7 @@ export function TransferForm({
                     </div>
                 ) : null}
                 {step === JOURNEY_STEPS.secondSelector ? (
-                    <div className={styles.stepContent}>
+                    <div className={styles.stepContent} ref={stepContentRef}>
                         <SecondSelector
                             availablePlayers={availablePlayers}
                             selectedManager={selectedManager}
@@ -639,7 +651,7 @@ export function TransferForm({
                     </div>
                 ) : null}
                 {step === JOURNEY_STEPS.review ? (
-                    <div className={styles.stepContent}>
+                    <div className={styles.stepContent} ref={stepContentRef}>
                         <SelectorReview
                             transferType={transferType}
                             playerSelection={playerSelection}

--- a/draft/app/transfers/components/transfer-type-selector.module.css
+++ b/draft/app/transfers/components/transfer-type-selector.module.css
@@ -36,6 +36,13 @@
     border-bottom-right-radius: 0;
 }
 
+.dropdownButton.openUpward {
+    border-bottom-left-radius: var(--radius-md);
+    border-bottom-right-radius: var(--radius-md);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
 .selectedContent {
     flex: 1;
     display: flex;
@@ -90,6 +97,18 @@
     box-shadow: var(--shadow-lg);
     max-height: 300px;
     overflow-y: auto;
+}
+
+.dropdownMenuUpward {
+    top: auto;
+    bottom: 100%;
+    border-top: 1px solid var(--color-primary);
+    border-bottom: none;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-top-left-radius: var(--radius-md);
+    border-top-right-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
 }
 
 .dropdownOption {

--- a/draft/app/transfers/components/transfer-type-selector.tsx
+++ b/draft/app/transfers/components/transfer-type-selector.tsx
@@ -1,6 +1,6 @@
 /* Location: app/transfers/components/transfer-type-selector.tsx */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { TransferType } from '../types/transfer-types';
 import styles from './transfer-type-selector.module.css';
 
@@ -46,11 +46,33 @@ const TRANSFER_TYPES: Array<{
     },
 ];
 
+const MENU_MAX_HEIGHT_PX = 300;
+const VIEWPORT_EDGE_GAP_PX = 8;
+
 export function TransferTypeSelector({ selectedType, onTypeChange }: TransferTypeSelectorProps) {
     const [isOpen, setIsOpen] = useState(false);
+    const [opensUpward, setOpensUpward] = useState(false);
+    const [menuMaxHeight, setMenuMaxHeight] = useState(MENU_MAX_HEIGHT_PX);
     const dropdownRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
 
     const selectedTypeData = TRANSFER_TYPES.find((type) => type.value === selectedType);
+
+    const updateMenuPlacement = () => {
+        const button = buttonRef.current;
+        if (!button) {
+            return;
+        }
+
+        const rect = button.getBoundingClientRect();
+        const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_EDGE_GAP_PX;
+        const spaceAbove = rect.top - VIEWPORT_EDGE_GAP_PX;
+        const shouldOpenUpward = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
+        const availableSpace = shouldOpenUpward ? spaceAbove : spaceBelow;
+
+        setOpensUpward(shouldOpenUpward);
+        setMenuMaxHeight(Math.max(120, Math.min(MENU_MAX_HEIGHT_PX, availableSpace)));
+    };
 
     const handleTypeSelect = (type: TransferType) => {
         onTypeChange(type);
@@ -83,26 +105,51 @@ export function TransferTypeSelector({ selectedType, onTypeChange }: TransferTyp
         }
     };
 
-    // Close dropdown when clicking outside
+    useLayoutEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        updateMenuPlacement();
+    }, [isOpen]);
+
+    // Close dropdown when clicking outside; keep placement valid on resize/scroll
     useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
         const handleClickOutside = (event: MouseEvent) => {
             if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
                 setIsOpen(false);
             }
         };
 
+        const handleReposition = () => {
+            updateMenuPlacement();
+        };
+
         document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
+        window.addEventListener('resize', handleReposition);
+        window.addEventListener('scroll', handleReposition, true);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            window.removeEventListener('resize', handleReposition);
+            window.removeEventListener('scroll', handleReposition, true);
+        };
+    }, [isOpen]);
 
     return (
-        <div className={styles.dropdownContainer}>
+        <div className={styles.dropdownContainer} ref={dropdownRef}>
             <button
                 id="transfer-type-dropdown"
+                ref={buttonRef}
                 type="button"
                 onClick={() => setIsOpen(!isOpen)}
                 onKeyDown={handleKeyDown}
-                className={`${styles.dropdownButton} ${isOpen ? styles.open : ''}`}
+                className={`${styles.dropdownButton} ${isOpen ? styles.open : ''} ${
+                    isOpen && opensUpward ? styles.openUpward : ''
+                }`}
                 aria-expanded={isOpen}
                 aria-haspopup="listbox"
             >
@@ -120,7 +167,11 @@ export function TransferTypeSelector({ selectedType, onTypeChange }: TransferTyp
             </button>
 
             {isOpen && (
-                <div className={styles.dropdownMenu} role="listbox">
+                <div
+                    className={`${styles.dropdownMenu} ${opensUpward ? styles.dropdownMenuUpward : ''}`}
+                    role="listbox"
+                    style={{ maxHeight: `${menuMaxHeight}px` }}
+                >
                     {TRANSFER_TYPES.map((type) => (
                         <button
                             key={type.value}

--- a/draft/app/transfers/components/transfer-type-selector.tsx
+++ b/draft/app/transfers/components/transfer-type-selector.tsx
@@ -1,6 +1,8 @@
 /* Location: app/transfers/components/transfer-type-selector.tsx */
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useClickOutside } from '../hooks/use-click-outside';
+import { useDropdownMenuPlacement } from '../hooks/use-dropdown-menu-placement';
 import type { TransferType } from '../types/transfer-types';
 import styles from './transfer-type-selector.module.css';
 
@@ -46,33 +48,16 @@ const TRANSFER_TYPES: Array<{
     },
 ];
 
-const MENU_MAX_HEIGHT_PX = 300;
-const VIEWPORT_EDGE_GAP_PX = 8;
-
 export function TransferTypeSelector({ selectedType, onTypeChange }: TransferTypeSelectorProps) {
     const [isOpen, setIsOpen] = useState(false);
-    const [opensUpward, setOpensUpward] = useState(false);
-    const [menuMaxHeight, setMenuMaxHeight] = useState(MENU_MAX_HEIGHT_PX);
     const dropdownRef = useRef<HTMLDivElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
+    const { opensUpward, menuMaxHeight } = useDropdownMenuPlacement(isOpen, buttonRef);
+    const closeDropdown = useCallback(() => setIsOpen(false), []);
+
+    useClickOutside(dropdownRef, closeDropdown, isOpen);
 
     const selectedTypeData = TRANSFER_TYPES.find((type) => type.value === selectedType);
-
-    const updateMenuPlacement = () => {
-        const button = buttonRef.current;
-        if (!button) {
-            return;
-        }
-
-        const rect = button.getBoundingClientRect();
-        const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_EDGE_GAP_PX;
-        const spaceAbove = rect.top - VIEWPORT_EDGE_GAP_PX;
-        const shouldOpenUpward = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
-        const availableSpace = shouldOpenUpward ? spaceAbove : spaceBelow;
-
-        setOpensUpward(shouldOpenUpward);
-        setMenuMaxHeight(Math.max(120, Math.min(MENU_MAX_HEIGHT_PX, availableSpace)));
-    };
 
     const handleTypeSelect = (type: TransferType) => {
         onTypeChange(type);
@@ -88,7 +73,6 @@ export function TransferTypeSelector({ selectedType, onTypeChange }: TransferTyp
         } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
             e.preventDefault();
             if (isOpen) {
-                // Handle arrow navigation
                 const currentIndex = TRANSFER_TYPES.findIndex((type) => type.value === selectedType);
                 let newIndex;
 
@@ -104,40 +88,6 @@ export function TransferTypeSelector({ selectedType, onTypeChange }: TransferTyp
             }
         }
     };
-
-    useLayoutEffect(() => {
-        if (!isOpen) {
-            return;
-        }
-
-        updateMenuPlacement();
-    }, [isOpen]);
-
-    // Close dropdown when clicking outside; keep placement valid on resize/scroll
-    useEffect(() => {
-        if (!isOpen) {
-            return;
-        }
-
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setIsOpen(false);
-            }
-        };
-
-        const handleReposition = () => {
-            updateMenuPlacement();
-        };
-
-        document.addEventListener('mousedown', handleClickOutside);
-        window.addEventListener('resize', handleReposition);
-        window.addEventListener('scroll', handleReposition, true);
-        return () => {
-            document.removeEventListener('mousedown', handleClickOutside);
-            window.removeEventListener('resize', handleReposition);
-            window.removeEventListener('scroll', handleReposition, true);
-        };
-    }, [isOpen]);
 
     return (
         <div className={styles.dropdownContainer} ref={dropdownRef}>

--- a/draft/app/transfers/hooks/use-click-outside.ts
+++ b/draft/app/transfers/hooks/use-click-outside.ts
@@ -1,0 +1,27 @@
+/* Location: app/transfers/hooks/use-click-outside.ts */
+
+import { type RefObject, useEffect } from 'react';
+
+/**
+ * Calls `onOutside` when a mousedown happens outside `ref`, while `enabled` is true.
+ */
+export function useClickOutside(
+    ref: RefObject<HTMLElement | null>,
+    onOutside: () => void,
+    enabled: boolean,
+): void {
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        const handleClickOutside = (event: MouseEvent) => {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                onOutside();
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [ref, onOutside, enabled]);
+}

--- a/draft/app/transfers/hooks/use-dropdown-menu-placement.ts
+++ b/draft/app/transfers/hooks/use-dropdown-menu-placement.ts
@@ -1,0 +1,67 @@
+/* Location: app/transfers/hooks/use-dropdown-menu-placement.ts */
+
+import { type RefObject, useCallback, useEffect, useLayoutEffect, useState } from 'react';
+
+const MENU_MAX_HEIGHT_PX = 300;
+const VIEWPORT_EDGE_GAP_PX = 8;
+const MENU_MIN_HEIGHT_PX = 120;
+
+interface UseDropdownMenuPlacementResult {
+    opensUpward: boolean;
+    menuMaxHeight: number;
+}
+
+/**
+ * Positions a dropdown menu above or below its trigger based on available viewport space,
+ * and caps max-height so options remain reachable on short screens.
+ */
+export function useDropdownMenuPlacement(
+    isOpen: boolean,
+    buttonRef: RefObject<HTMLElement | null>,
+): UseDropdownMenuPlacementResult {
+    const [opensUpward, setOpensUpward] = useState(false);
+    const [menuMaxHeight, setMenuMaxHeight] = useState(MENU_MAX_HEIGHT_PX);
+
+    const updateMenuPlacement = useCallback(() => {
+        const button = buttonRef.current;
+        if (!button) {
+            return;
+        }
+
+        const rect = button.getBoundingClientRect();
+        const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_EDGE_GAP_PX;
+        const spaceAbove = rect.top - VIEWPORT_EDGE_GAP_PX;
+        const shouldOpenUpward = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
+        const availableSpace = shouldOpenUpward ? spaceAbove : spaceBelow;
+
+        setOpensUpward(shouldOpenUpward);
+        setMenuMaxHeight(Math.max(MENU_MIN_HEIGHT_PX, Math.min(MENU_MAX_HEIGHT_PX, availableSpace)));
+    }, [buttonRef]);
+
+    useLayoutEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        updateMenuPlacement();
+    }, [isOpen, updateMenuPlacement]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handleReposition = () => {
+            updateMenuPlacement();
+        };
+
+        window.addEventListener('resize', handleReposition);
+        window.addEventListener('scroll', handleReposition, true);
+        return () => {
+            window.removeEventListener('resize', handleReposition);
+            window.removeEventListener('scroll', handleReposition, true);
+        };
+    }, [isOpen, updateMenuPlacement]);
+
+    return { opensUpward, menuMaxHeight };
+}


### PR DESCRIPTION
## Summary
- Polish player-out/player-in mobile layout: keep all stats + horizontal scroll, dense rows, zebra striping, sticky Player, stacked full-width player-in filters, and journey list height parity
- Fix journey step scroll so Continue/Back starts each step at the top; collision-aware transfer-type dropdown in the sticky footer so all options stay reachable
- Rename review CTA to generic “Submit” for all transaction types

## Test plan
- [ ] Team-first and player-list-first: select a player mid-list, Continue — next step opens at the top
- [ ] At ~414px: all stat columns reachable via horizontal scroll; Player column sticks; zebra rows + selection still clear
- [ ] Player-in: filters stack full-width; search/position/team/status still work
- [ ] After selecting first player: open transfer type — menu opens upward/fits viewport; all options selectable
- [ ] Review step CTA reads “Submit”; submit still works for TRANSFER (spot-check SWAP)
- [ ] Skip deep loan QA (separate review)


Made with [Cursor](https://cursor.com)