### PR TITLE
Hide Players from main navigation

### DIFF
--- a/draft/app/root.tsx
+++ b/draft/app/root.tsx
@@ -129,7 +129,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
 const navigationItems = [
     { href: '/leagues', label: 'League Standings' },
     { href: '/teams?tab=all-teams', label: 'Teams' },
-    { href: '/players', label: 'Players' },
     { href: '/transfers', label: 'Transfers' },
     { href: '/cup', label: 'Cup' },
     { href: '/wishlists', label: 'Wishlists' },


### PR DESCRIPTION
## Summary
- Remove the Players item from the shared main nav config in `root.tsx` (desktop and mobile).
- Keep `/players` and `/players/:playerCode` routes intact so the page remains reachable by direct URL and existing deep links.

## Test plan
- [ ] Confirm desktop and mobile nav no longer show Players
- [ ] Confirm `/players` still loads when visited directly
- [ ] Confirm `/players/:playerCode` still loads from Teams/Wishlist deep links
- [ ] Confirm wishlist “Browse Players” still works


Made with [Cursor](https://cursor.com)