### PR TITLE
Add admin copy player stats for Google Sheets

### DIFF
--- a/draft/app/admin/components/sections/overview-section.tsx
+++ b/draft/app/admin/components/sections/overview-section.tsx
@@ -9,6 +9,7 @@ import { AdminContainer } from '../layout/admin-container';
 import { AdminGrid } from '../layout/admin-grid';
 import { AdminSection } from '../layout/admin-section';
 import { AdminMessage } from '../ui/admin-message';
+import { CopyPlayerStats } from '../ui/copy-player-stats';
 import { StatusCard } from '../ui/status-card';
 import styles from './overview-section.module.css';
 
@@ -104,6 +105,8 @@ export function OverviewSection({ systemStatus }: OverviewSectionProps) {
                     ))}
                 </ul>
             </AdminSection>
+
+            <CopyPlayerStats currentGameweekId={systemStatus.currentGameweek.fplEvent.id} />
 
             {/* Action Messages */}
             {actionData?.success && actionData.message && (

--- a/draft/app/admin/components/ui/copy-player-stats.module.css
+++ b/draft/app/admin/components/ui/copy-player-stats.module.css
@@ -1,0 +1,36 @@
+/* Location: app/admin/components/ui/copy-player-stats.module.css */
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+}
+
+.controlsRow {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: var(--spacing-3);
+}
+
+.scopeLabel {
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+}
+
+.scopeLabelText {
+    font-size: var(--font-sm);
+    font-weight: 500;
+    color: var(--color-gray-700);
+}
+
+.scopeSelect {
+    min-width: 10rem;
+    padding: var(--spacing-2) var(--spacing-3);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-md);
+    background: var(--color-white);
+    font-size: var(--font-sm);
+    color: var(--color-gray-900);
+}

--- a/draft/app/admin/components/ui/copy-player-stats.tsx
+++ b/draft/app/admin/components/ui/copy-player-stats.tsx
@@ -1,0 +1,91 @@
+/* Location: app/admin/components/ui/copy-player-stats.tsx */
+
+import { useState } from 'react';
+import { buildPlayerStatsTsv } from '../../../players/lib/player-stats-tsv';
+import type { PlayerStatsData } from '../../../players/types/player-types';
+import * as Icons from '../icons/admin-icons';
+import { AdminSection } from '../layout/admin-section';
+import { AdminButton } from './admin-button';
+import { AdminMessage } from './admin-message';
+import styles from './copy-player-stats.module.css';
+
+const SEASON_VALUE = 'season';
+
+interface CopyPlayerStatsProps {
+    currentGameweekId: number;
+}
+
+export function CopyPlayerStats({ currentGameweekId }: CopyPlayerStatsProps) {
+    const [scope, setScope] = useState<string>(SEASON_VALUE);
+    const [isLoading, setIsLoading] = useState(false);
+    const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+    const availableGameweeks = Array.from({ length: currentGameweekId }, (_, i) => i + 1);
+
+    const handleCopy = async () => {
+        setIsLoading(true);
+        setMessage(null);
+
+        try {
+            const url = scope === SEASON_VALUE ? '/players.json' : `/players.json?gameweek=${scope}`;
+            const response = await fetch(url);
+
+            if (!response.ok) {
+                throw new Error(`Failed to load player stats (${response.status})`);
+            }
+
+            const data = (await response.json()) as PlayerStatsData;
+            const tsv = buildPlayerStatsTsv(data);
+
+            await navigator.clipboard.writeText(tsv);
+
+            const scopeLabel = scope === SEASON_VALUE ? 'season to date' : `GW ${scope}`;
+            setMessage({
+                type: 'success',
+                text: `Copied ${data.players.length} players (${scopeLabel}) to clipboard. Paste into Google Sheets.`,
+            });
+        } catch (error) {
+            setMessage({
+                type: 'error',
+                text: error instanceof Error ? error.message : 'Failed to copy player stats',
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <AdminSection
+            title="Copy Player Stats"
+            icon={<Icons.FileIcon />}
+            description="Copy the full players table as TSV for pasting into Google Sheets"
+        >
+            <div className={styles.controls}>
+                <div className={styles.controlsRow}>
+                    <label className={styles.scopeLabel}>
+                        <span className={styles.scopeLabelText}>Scope</span>
+                        <select
+                            className={styles.scopeSelect}
+                            value={scope}
+                            onChange={(event) => setScope(event.target.value)}
+                            disabled={isLoading}
+                        >
+                            <option value={SEASON_VALUE}>Season to date</option>
+                            {availableGameweeks.map((gameweek) => (
+                                <option key={gameweek} value={String(gameweek)}>
+                                    Gameweek {gameweek}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+
+                    <AdminButton variant="primary" onClick={handleCopy} loading={isLoading} disabled={isLoading}>
+                        Copy to clipboard
+                    </AdminButton>
+                </div>
+
+                {message && <AdminMessage type={message.type}>{message.text}</AdminMessage>}
+            </div>
+        </AdminSection>
+    );
+}

--- a/draft/app/players/lib/player-stats-tsv.test.ts
+++ b/draft/app/players/lib/player-stats-tsv.test.ts
@@ -1,0 +1,159 @@
+/* Location: app/players/lib/player-stats-tsv.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { EnhancedPlayerData } from '../../scoring/types/scoring-types';
+import type { PlayerStatsData } from '../types/player-types';
+import { buildPlayerStatsTsv, PLAYER_STATS_TSV_HEADERS } from './player-stats-tsv';
+
+function breakdownItem(stat: number) {
+    return { label: '', points: 0, stat, formula: '' };
+}
+
+function makePlayer(overrides: {
+    web_name: string;
+    team_code: number;
+    position: EnhancedPlayerData['draft']['position'];
+    pointsTotal: number;
+    stats?: Partial<Record<keyof EnhancedPlayerData['draft']['pointsBreakdown'], number>>;
+}): EnhancedPlayerData {
+    const stats = overrides.stats ?? {};
+    return {
+        id: 1,
+        code: 1,
+        first_name: 'Test',
+        second_name: 'Player',
+        web_name: overrides.web_name,
+        team_code: overrides.team_code,
+        draft: {
+            position: overrides.position,
+            pointsTotal: overrides.pointsTotal,
+            pointsBreakdown: {
+                appearance: breakdownItem(stats.appearance ?? 90),
+                goals: breakdownItem(stats.goals ?? 0),
+                assists: breakdownItem(stats.assists ?? 0),
+                cleanSheets: breakdownItem(stats.cleanSheets ?? 0),
+                yellowCards: breakdownItem(stats.yellowCards ?? 0),
+                redCards: breakdownItem(stats.redCards ?? 0),
+                saves: breakdownItem(stats.saves ?? 0),
+                penaltiesSaved: breakdownItem(stats.penaltiesSaved ?? 0),
+                goalsConceded: breakdownItem(stats.goalsConceded ?? 0),
+                bonus: breakdownItem(stats.bonus ?? 0),
+                defensiveContribution: breakdownItem(stats.defensiveContribution ?? 0),
+                total: breakdownItem(overrides.pointsTotal),
+            },
+        },
+    };
+}
+
+function makeData(players: EnhancedPlayerData[]): PlayerStatsData {
+    return {
+        players,
+        teamsByCode: {
+            1: { code: 1, id: 1, name: 'Arsenal', short_name: 'ARS' },
+            2: { code: 2, id: 2, name: 'Chelsea', short_name: 'CHE' },
+        } as PlayerStatsData['teamsByCode'],
+        positions: { gk: 'gk', fb: 'fb', cb: 'cb', mid: 'mid', wa: 'wa', ca: 'ca' },
+    };
+}
+
+describe('buildPlayerStatsTsv', () => {
+    it('starts with the expected header row', () => {
+        const tsv = buildPlayerStatsTsv(makeData([]));
+        expect(tsv).toBe(PLAYER_STATS_TSV_HEADERS.join('\t'));
+    });
+
+    it('exports a player row with team and position columns', () => {
+        const tsv = buildPlayerStatsTsv(
+            makeData([
+                makePlayer({
+                    web_name: 'Salah',
+                    team_code: 1,
+                    position: 'wa',
+                    pointsTotal: 42,
+                    stats: { appearance: 180, goals: 3, assists: 1 },
+                }),
+            ]),
+        );
+
+        const [, row] = tsv.split('\n');
+        const cells = row.split('\t');
+
+        expect(cells[0]).toBe('Salah');
+        expect(cells[1]).toBe('ARS');
+        expect(cells[2]).toBe('WA');
+        expect(cells[3]).toBe('42');
+        expect(cells[4]).toBe('180');
+        expect(cells[5]).toBe('3');
+        expect(cells[6]).toBe('1');
+    });
+
+    it('leaves irrelevant position stats blank', () => {
+        const tsv = buildPlayerStatsTsv(
+            makeData([
+                makePlayer({
+                    web_name: 'Haaland',
+                    team_code: 2,
+                    position: 'ca',
+                    pointsTotal: 50,
+                    stats: {
+                        cleanSheets: 5,
+                        penaltiesSaved: 1,
+                        saves: 10,
+                        goalsConceded: 2,
+                        bonus: 3,
+                        defensiveContribution: 8,
+                    },
+                }),
+            ]),
+        );
+
+        const cells = tsv.split('\n')[1].split('\t');
+        // Clean Sheets, Pens Saved, Saves, Goals Con., Bonus, Def. Con.
+        expect(cells[7]).toBe('-');
+        expect(cells[8]).toBe('-');
+        expect(cells[9]).toBe('-');
+        expect(cells[10]).toBe('-');
+        expect(cells[13]).toBe('-');
+        expect(cells[14]).toBe('-');
+    });
+
+    it('includes relevant GK defensive stats', () => {
+        const tsv = buildPlayerStatsTsv(
+            makeData([
+                makePlayer({
+                    web_name: 'Raya',
+                    team_code: 1,
+                    position: 'gk',
+                    pointsTotal: 30,
+                    stats: {
+                        cleanSheets: 2,
+                        penaltiesSaved: 1,
+                        saves: 12,
+                        goalsConceded: 3,
+                    },
+                }),
+            ]),
+        );
+
+        const cells = tsv.split('\n')[1].split('\t');
+        expect(cells[7]).toBe('2');
+        expect(cells[8]).toBe('1');
+        expect(cells[9]).toBe('12');
+        expect(cells[10]).toBe('3');
+        expect(cells[13]).toBe('-'); // bonus not relevant for GK
+        expect(cells[14]).toBe('-'); // def con not relevant for GK
+    });
+
+    it('sorts players by points descending', () => {
+        const tsv = buildPlayerStatsTsv(
+            makeData([
+                makePlayer({ web_name: 'Low', team_code: 1, position: 'mid', pointsTotal: 10 }),
+                makePlayer({ web_name: 'High', team_code: 2, position: 'ca', pointsTotal: 99 }),
+            ]),
+        );
+
+        const rows = tsv.split('\n').slice(1);
+        expect(rows[0].split('\t')[0]).toBe('High');
+        expect(rows[1].split('\t')[0]).toBe('Low');
+    });
+});

--- a/draft/app/players/lib/player-stats-tsv.test.ts
+++ b/draft/app/players/lib/player-stats-tsv.test.ts
@@ -14,12 +14,13 @@ function makePlayer(overrides: {
     team_code: number;
     position: EnhancedPlayerData['draft']['position'];
     pointsTotal: number;
+    code?: number;
     stats?: Partial<Record<keyof EnhancedPlayerData['draft']['pointsBreakdown'], number>>;
 }): EnhancedPlayerData {
     const stats = overrides.stats ?? {};
     return {
         id: 1,
-        code: 1,
+        code: overrides.code ?? 1,
         first_name: 'Test',
         second_name: 'Player',
         web_name: overrides.web_name,
@@ -67,6 +68,7 @@ describe('buildPlayerStatsTsv', () => {
             makeData([
                 makePlayer({
                     web_name: 'Salah',
+                    code: 118748,
                     team_code: 1,
                     position: 'wa',
                     pointsTotal: 42,
@@ -78,16 +80,17 @@ describe('buildPlayerStatsTsv', () => {
         const [, row] = tsv.split('\n');
         const cells = row.split('\t');
 
-        expect(cells[0]).toBe('Salah');
-        expect(cells[1]).toBe('ARS');
-        expect(cells[2]).toBe('WA');
-        expect(cells[3]).toBe('42');
-        expect(cells[4]).toBe('180');
-        expect(cells[5]).toBe('3');
-        expect(cells[6]).toBe('1');
+        expect(cells[0]).toBe('118748');
+        expect(cells[1]).toBe('Salah');
+        expect(cells[2]).toBe('ARS');
+        expect(cells[3]).toBe('WA');
+        expect(cells[4]).toBe('42');
+        expect(cells[5]).toBe('180');
+        expect(cells[6]).toBe('3');
+        expect(cells[7]).toBe('1');
     });
 
-    it('leaves irrelevant position stats blank', () => {
+    it('fills irrelevant position stats with 0 for formula-friendly export', () => {
         const tsv = buildPlayerStatsTsv(
             makeData([
                 makePlayer({
@@ -109,12 +112,12 @@ describe('buildPlayerStatsTsv', () => {
 
         const cells = tsv.split('\n')[1].split('\t');
         // Clean Sheets, Pens Saved, Saves, Goals Con., Bonus, Def. Con.
-        expect(cells[7]).toBe('-');
-        expect(cells[8]).toBe('-');
-        expect(cells[9]).toBe('-');
-        expect(cells[10]).toBe('-');
-        expect(cells[13]).toBe('-');
-        expect(cells[14]).toBe('-');
+        expect(cells[8]).toBe('0');
+        expect(cells[9]).toBe('0');
+        expect(cells[10]).toBe('0');
+        expect(cells[11]).toBe('0');
+        expect(cells[14]).toBe('0');
+        expect(cells[15]).toBe('0');
     });
 
     it('includes relevant GK defensive stats', () => {
@@ -136,12 +139,12 @@ describe('buildPlayerStatsTsv', () => {
         );
 
         const cells = tsv.split('\n')[1].split('\t');
-        expect(cells[7]).toBe('2');
-        expect(cells[8]).toBe('1');
-        expect(cells[9]).toBe('12');
-        expect(cells[10]).toBe('3');
-        expect(cells[13]).toBe('-'); // bonus not relevant for GK
-        expect(cells[14]).toBe('-'); // def con not relevant for GK
+        expect(cells[8]).toBe('2');
+        expect(cells[9]).toBe('1');
+        expect(cells[10]).toBe('12');
+        expect(cells[11]).toBe('3');
+        expect(cells[14]).toBe('0'); // bonus not relevant for GK
+        expect(cells[15]).toBe('0'); // def con not relevant for GK
     });
 
     it('sorts players by points descending', () => {
@@ -153,7 +156,7 @@ describe('buildPlayerStatsTsv', () => {
         );
 
         const rows = tsv.split('\n').slice(1);
-        expect(rows[0].split('\t')[0]).toBe('High');
-        expect(rows[1].split('\t')[0]).toBe('Low');
+        expect(rows[0].split('\t')[1]).toBe('High');
+        expect(rows[1].split('\t')[1]).toBe('Low');
     });
 });

--- a/draft/app/players/lib/player-stats-tsv.ts
+++ b/draft/app/players/lib/player-stats-tsv.ts
@@ -1,0 +1,67 @@
+/* Location: app/players/lib/player-stats-tsv.ts */
+
+import { isStatRelevant } from '../../scoring/lib';
+import type { EnhancedPlayerData } from '../../scoring/types/scoring-types';
+import type { PlayerStatsData } from '../types/player-types';
+
+export const PLAYER_STATS_TSV_HEADERS = [
+    'Player',
+    'Team',
+    'Position',
+    'Points',
+    'Mins',
+    'Goals',
+    'Assists',
+    'Clean Sheets',
+    'Pens Saved',
+    'Saves',
+    'Goals Con.',
+    'Yellow Cards',
+    'Red Cards',
+    'Bonus',
+    'Def. Con.',
+] as const;
+
+function escapeTsvCell(value: string | number): string {
+    return String(value).replace(/\t/g, ' ').replace(/\r?\n/g, ' ');
+}
+
+function formatStatCell(player: EnhancedPlayerData, statKey: string, value: number | undefined): string {
+    if (!isStatRelevant(statKey, player.draft.position)) {
+        return '-';
+    }
+    return escapeTsvCell(value ?? 0);
+}
+
+function playerToTsvRow(player: EnhancedPlayerData, teamShortName: string): string {
+    const breakdown = player.draft.pointsBreakdown;
+
+    return [
+        escapeTsvCell(player.web_name),
+        escapeTsvCell(teamShortName),
+        escapeTsvCell(player.draft.position.toUpperCase()),
+        escapeTsvCell(player.draft.pointsTotal),
+        escapeTsvCell(breakdown.appearance.stat ?? 0),
+        escapeTsvCell(breakdown.goals.stat ?? 0),
+        escapeTsvCell(breakdown.assists.stat ?? 0),
+        formatStatCell(player, 'cleanSheets', breakdown.cleanSheets.stat),
+        formatStatCell(player, 'penaltiesSaved', breakdown.penaltiesSaved.stat),
+        formatStatCell(player, 'saves', breakdown.saves.stat),
+        formatStatCell(player, 'goalsConceded', breakdown.goalsConceded.stat),
+        escapeTsvCell(breakdown.yellowCards.stat ?? 0),
+        escapeTsvCell(breakdown.redCards.stat ?? 0),
+        formatStatCell(player, 'bonus', breakdown.bonus.stat),
+        formatStatCell(player, 'defensiveContribution', breakdown.defensiveContribution.stat),
+    ].join('\t');
+}
+
+export function buildPlayerStatsTsv(data: PlayerStatsData): string {
+    const sortedPlayers = [...data.players].sort((a, b) => b.draft.pointsTotal - a.draft.pointsTotal);
+
+    const rows = sortedPlayers.map((player) => {
+        const teamShortName = data.teamsByCode[player.team_code]?.short_name ?? '';
+        return playerToTsvRow(player, teamShortName);
+    });
+
+    return [PLAYER_STATS_TSV_HEADERS.join('\t'), ...rows].join('\n');
+}

--- a/draft/app/players/lib/player-stats-tsv.ts
+++ b/draft/app/players/lib/player-stats-tsv.ts
@@ -5,6 +5,7 @@ import type { EnhancedPlayerData } from '../../scoring/types/scoring-types';
 import type { PlayerStatsData } from '../types/player-types';
 
 export const PLAYER_STATS_TSV_HEADERS = [
+    'Code',
     'Player',
     'Team',
     'Position',
@@ -28,7 +29,7 @@ function escapeTsvCell(value: string | number): string {
 
 function formatStatCell(player: EnhancedPlayerData, statKey: string, value: number | undefined): string {
     if (!isStatRelevant(statKey, player.draft.position)) {
-        return '-';
+        return '0';
     }
     return escapeTsvCell(value ?? 0);
 }
@@ -37,6 +38,7 @@ function playerToTsvRow(player: EnhancedPlayerData, teamShortName: string): stri
     const breakdown = player.draft.pointsBreakdown;
 
     return [
+        escapeTsvCell(player.code),
         escapeTsvCell(player.web_name),
         escapeTsvCell(teamShortName),
         escapeTsvCell(player.draft.position.toUpperCase()),


### PR DESCRIPTION
## Summary
- Adds a **Copy Player Stats** section on the admin overview to copy the full `/players` stats table as TSV for pasting into Google Sheets
- Supports season-to-date or a specific gameweek via a local scope selector
- Exports team short codes (e.g. ARS), short positions (e.g. WA), and `-` for irrelevant position stats

## Test plan
- [ ] Open `/admin` and confirm the Copy Player Stats section appears
- [ ] Copy season-to-date and paste into Google Sheets; columns and rows look correct
- [ ] Copy a specific gameweek and confirm stats match `/players?gameweek=N`
- [ ] Confirm irrelevant stats show `-` (e.g. pens saved for attackers)
- [ ] Confirm team uses 3-letter codes and positions use short form (GK/FB/CB/MID/WA/CA)


Made with [Cursor](https://cursor.com)