### PR TITLE
Harden admin/Sheets against OAuth hang failures

### DIFF
--- a/.kiro/steering/ai-contribution-rules.md
+++ b/.kiro/steering/ai-contribution-rules.md
@@ -71,6 +71,10 @@ Every data read is cached. If you change what a loader fetches, or add a new dat
 
 ## Coding Standards
 
+### Do not nest medium, large, or pure helpers
+
+Where possible, medium-to-large functions — and any function that is pure or can easily be made pure — must not be nested inside another function. Define them at module scope (or extract to a util) and pass dependencies as arguments. Nested one-liners and tiny closures that only close over adjacent locals are fine; anything substantial enough to name or reuse is not.
+
 ### TypeScript is non-negotiable
 
 All new files are TypeScript. No `any` unless there is an explicit comment explaining why. Prefer narrow types over wide ones.

--- a/draft/app/_shared/lib/fpl/api-cache.ts
+++ b/draft/app/_shared/lib/fpl/api-cache.ts
@@ -18,6 +18,37 @@ import type {
     GameWeekData,
 } from './fpl-types';
 
+const CACHE_STATUS_TIMEOUT_MS = 15_000;
+
+/**
+ * Resolve a promise within a timeout, returning fallback on expiry.
+ * Pure helper kept at module scope (not nested inside callers).
+ */
+async function withTimeoutFallback<T>(
+    promise: Promise<T>,
+    fallback: T,
+    label: string,
+    timeoutMs = CACHE_STATUS_TIMEOUT_MS,
+): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+        const result = await Promise.race([
+            promise.then((value) => ({ ok: true as const, value })),
+            new Promise<{ ok: false }>((resolve) => {
+                timeoutId = setTimeout(() => resolve({ ok: false }), timeoutMs);
+            }),
+        ]);
+
+        if (!result.ok) {
+            console.warn(`⚠️ getCacheStatus() - ${label} timed out after ${timeoutMs}ms`);
+            return fallback;
+        }
+        return result.value;
+    } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+    }
+}
+
 /**
  * Updated FPL Data Orchestrator - Uses Individual Player Caching
  * Fixes cache key explosion by caching individual players instead of batches
@@ -362,37 +393,15 @@ class FplApiCache {
     async getCacheStatus() {
         console.log('🔄 getCacheStatus() - Getting fresh status');
 
-        const timeoutMs = 15_000;
-
-        const withTimeout = async <T>(promise: Promise<T>, fallback: T, label: string): Promise<T> => {
-            let timeoutId: ReturnType<typeof setTimeout> | undefined;
-            try {
-                const result = await Promise.race([
-                    promise.then((value) => ({ ok: true as const, value })),
-                    new Promise<{ ok: false }>((resolve) => {
-                        timeoutId = setTimeout(() => resolve({ ok: false }), timeoutMs);
-                    }),
-                ]);
-
-                if (!result.ok) {
-                    console.warn(`⚠️ getCacheStatus() - ${label} timed out after ${timeoutMs}ms`);
-                    return fallback;
-                }
-                return result.value;
-            } finally {
-                if (timeoutId) clearTimeout(timeoutId);
-            }
-        };
-
         // Load elements once — getElementsCount() previously re-read the same large document
-        const elements = await withTimeout(this.fplFirestore.getElements(), [], 'getElements');
+        const elements = await withTimeoutFallback(this.fplFirestore.getElements(), [], 'getElements');
         const elementsCount = elements.length;
         const hasDraftData = elements.some((player) => Boolean(player.draft));
 
         const [eventsCount, teamsCount, elementDetailedStatsCount] = await Promise.all([
-            withTimeout(this.fplFirestore.getEventsCount(), 0, 'getEventsCount'),
-            withTimeout(this.fplFirestore.getTeamsCount(), 0, 'getTeamsCount'),
-            withTimeout(this.fplFirestore.getElementDetailedStatsCount(), 0, 'getElementDetailedStatsCount'),
+            withTimeoutFallback(this.fplFirestore.getEventsCount(), 0, 'getEventsCount'),
+            withTimeoutFallback(this.fplFirestore.getTeamsCount(), 0, 'getTeamsCount'),
+            withTimeoutFallback(this.fplFirestore.getElementDetailedStatsCount(), 0, 'getElementDetailedStatsCount'),
         ]);
 
         return {

--- a/draft/app/_shared/lib/fpl/api-cache.ts
+++ b/draft/app/_shared/lib/fpl/api-cache.ts
@@ -9,7 +9,14 @@ import { dataCache } from '../cache/data-cache.service';
 import { fuzzyStringMatch } from '../fuzzy-string-match';
 import { fplApi } from './api';
 import { FplFirestore } from './fpl-firestore';
-import type { FplBootstrapData, FplFixtureData, FplLiveData, FplPlayerSeasonData, FplTeam, GameWeekData } from './fpl-types';
+import type {
+    FplBootstrapData,
+    FplFixtureData,
+    FplLiveData,
+    FplPlayerSeasonData,
+    FplTeam,
+    GameWeekData,
+} from './fpl-types';
 
 /**
  * Updated FPL Data Orchestrator - Uses Individual Player Caching
@@ -355,16 +362,38 @@ class FplApiCache {
     async getCacheStatus() {
         console.log('🔄 getCacheStatus() - Getting fresh status');
 
-        // This should always be fresh to get accurate cache status
-        const [elements, elementsCount, eventsCount, teamsCount, elementDetailedStatsCount] = await Promise.all([
-            this.fplFirestore.getElements(),
-            this.fplFirestore.getElementsCount(),
-            this.fplFirestore.getEventsCount(),
-            this.fplFirestore.getTeamsCount(),
-            this.fplFirestore.getElementDetailedStatsCount(),
-        ]);
+        const timeoutMs = 15_000;
 
-        const hasDraftData = elements?.some((player) => player.draft) || false;
+        const withTimeout = async <T>(promise: Promise<T>, fallback: T, label: string): Promise<T> => {
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            try {
+                const result = await Promise.race([
+                    promise.then((value) => ({ ok: true as const, value })),
+                    new Promise<{ ok: false }>((resolve) => {
+                        timeoutId = setTimeout(() => resolve({ ok: false }), timeoutMs);
+                    }),
+                ]);
+
+                if (!result.ok) {
+                    console.warn(`⚠️ getCacheStatus() - ${label} timed out after ${timeoutMs}ms`);
+                    return fallback;
+                }
+                return result.value;
+            } finally {
+                if (timeoutId) clearTimeout(timeoutId);
+            }
+        };
+
+        // Load elements once — getElementsCount() previously re-read the same large document
+        const elements = await withTimeout(this.fplFirestore.getElements(), [], 'getElements');
+        const elementsCount = elements.length;
+        const hasDraftData = elements.some((player) => Boolean(player.draft));
+
+        const [eventsCount, teamsCount, elementDetailedStatsCount] = await Promise.all([
+            withTimeout(this.fplFirestore.getEventsCount(), 0, 'getEventsCount'),
+            withTimeout(this.fplFirestore.getTeamsCount(), 0, 'getTeamsCount'),
+            withTimeout(this.fplFirestore.getElementDetailedStatsCount(), 0, 'getElementDetailedStatsCount'),
+        ]);
 
         return {
             completionPercentage: elementsCount > 0 ? Math.round((elementDetailedStatsCount / elementsCount) * 100) : 0,

--- a/draft/app/_shared/lib/fpl/fpl-firestore.ts
+++ b/draft/app/_shared/lib/fpl/fpl-firestore.ts
@@ -58,7 +58,19 @@ export class FplFirestore {
         const doc = await this.client.getDocument<GameWeekData[]>(this.client.collections.FPL_BOOTSTRAP, 'events');
         this.lastUpdated.events = doc?.lastUpdated || '';
 
-        return doc ? doc.data.map((gw) => ({ ...gw, start: gw.start.toDate(), end: gw.end.toDate() })) : [];
+        if (!doc) return [];
+
+        return doc.data.map((gw) => ({
+            ...gw,
+            start:
+                typeof (gw.start as { toDate?: () => Date })?.toDate === 'function'
+                    ? (gw.start as { toDate: () => Date }).toDate()
+                    : new Date(gw.start as unknown as string | number | Date),
+            end:
+                typeof (gw.end as { toDate?: () => Date })?.toDate === 'function'
+                    ? (gw.end as { toDate: () => Date }).toDate()
+                    : new Date(gw.end as unknown as string | number | Date),
+        }));
     }
 
     /**

--- a/draft/app/_shared/lib/sheets/utils/common.ts
+++ b/draft/app/_shared/lib/sheets/utils/common.ts
@@ -25,56 +25,200 @@ export interface SheetWriteOptions {
     responseDateTimeRenderOption?: 'SERIAL_NUMBER' | 'FORMATTED_STRING';
 }
 
-// Initialize Google Sheets API client
-async function createSheetsClient() {
-    try {
-        if (!process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
-            throw new Error('GOOGLE_SERVICE_ACCOUNT_KEY environment variable is not set');
-        }
+let sheetsClientPromise: Promise<ReturnType<typeof google.sheets>> | null = null;
 
-        if (!SPREADSHEET_ID) {
-            throw new Error('GOOGLE_SHEETS_ID environment variable is not set');
-        }
+type GaxiosLikeRequest = {
+    method?: string;
+    url?: string;
+    data?: unknown;
+    body?: unknown;
+    headers?: Record<string, string>;
+    responseType?: string;
+    params?: Record<string, string | number | boolean | undefined>;
+    [key: string]: unknown;
+};
 
-        let credentials;
-        try {
-            const credentialsString = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
-            const decodedCredentials = atob(credentialsString);
-            credentials = JSON.parse(decodedCredentials);
+/**
+ * gaxios/node-fetch is failing with ERR_STREAM_PREMATURE_CLOSE against Google APIs
+ * in this environment. Native fetch (undici) works, so use that as the transporter.
+ */
+async function fetchTransporterRequest(opts: GaxiosLikeRequest) {
+    const method = (opts.method || 'GET').toUpperCase();
+    let url = opts.url || '';
 
-            if (!credentials.client_email || !credentials.private_key || !credentials.project_id) {
-                throw new Error('Invalid service account credentials - missing required fields');
+    if (opts.params && Object.keys(opts.params).length > 0) {
+        const qs = new URLSearchParams();
+        for (const [key, value] of Object.entries(opts.params)) {
+            if (value !== undefined && value !== null) {
+                qs.set(key, String(value));
             }
-        } catch (parseError) {
-            console.error('Failed to parse service account credentials:', parseError);
-            throw new Error("Invalid GOOGLE_SERVICE_ACCOUNT_KEY format. Ensure it's base64 encoded JSON.");
         }
+        url += (url.includes('?') ? '&' : '?') + qs.toString();
+    }
 
-        const auth = new google.auth.GoogleAuth({
-            credentials: {
-                type: credentials.type,
-                project_id: credentials.project_id,
-                private_key_id: credentials.private_key_id,
-                private_key: credentials.private_key,
-                client_email: credentials.client_email,
-                client_id: credentials.client_id,
-                auth_uri: credentials.auth_uri || 'https://accounts.google.com/o/oauth2/auth',
-                token_uri: credentials.token_uri || 'https://oauth2.googleapis.com/token',
-                auth_provider_x509_cert_url:
-                    credentials.auth_provider_x509_cert_url || 'https://www.googleapis.com/oauth2/v1/certs',
-                client_x509_cert_url: credentials.client_x509_cert_url,
-            },
-            scopes: SCOPES,
-        });
+    const headers = { ...(opts.headers || {}) };
+    let body: BodyInit | undefined;
 
-        const authClient = await auth.getClient();
-        const sheets = google.sheets({ version: 'v4', auth: authClient });
+    if (opts.data !== undefined && opts.data !== null && method !== 'GET' && method !== 'HEAD') {
+        if (typeof opts.data === 'string' || opts.data instanceof URLSearchParams) {
+            body = opts.data as BodyInit;
+            if (!headers['Content-Type'] && !headers['content-type']) {
+                headers['Content-Type'] = 'application/x-www-form-urlencoded';
+            }
+        } else if (Buffer.isBuffer(opts.data)) {
+            body = opts.data;
+        } else {
+            body = JSON.stringify(opts.data);
+            if (!headers['Content-Type'] && !headers['content-type']) {
+                headers['Content-Type'] = 'application/json';
+            }
+        }
+    } else if (opts.body !== undefined) {
+        body = opts.body as BodyInit;
+    }
 
-        return sheets;
-    } catch (error) {
-        console.error('Failed to initialize Google Sheets client:', error);
+    const response = await fetch(url, { method, headers, body });
+    const contentType = response.headers.get('content-type') || '';
+    let data: unknown;
+
+    if (opts.responseType === 'stream') {
+        data = response.body;
+    } else if (contentType.includes('application/json')) {
+        data = await response.json();
+    } else {
+        data = await response.text();
+    }
+
+    const headersObj: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+        headersObj[key] = value;
+    });
+
+    const result = {
+        data,
+        status: response.status,
+        statusText: response.statusText,
+        headers: headersObj,
+        config: opts,
+        request: { responseURL: response.url },
+    };
+
+    if (!response.ok) {
+        const error = new Error(
+            `Request failed with status ${response.status}: ${
+                typeof data === 'object' && data && 'error' in data
+                    ? JSON.stringify((data as { error: unknown }).error)
+                    : response.statusText
+            }`,
+        ) as Error & { response: typeof result; config: GaxiosLikeRequest; code?: number };
+        error.response = result;
+        error.config = opts;
+        error.code = response.status;
         throw error;
     }
+
+    return result;
+}
+
+function isRetryableAuthError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') return false;
+    const err = error as {
+        code?: string | number;
+        message?: string;
+        error?: { code?: string; message?: string };
+        details?: { code?: string; message?: string; error?: { code?: string; message?: string } };
+    };
+    const candidates = [
+        String(err.code ?? ''),
+        err.message,
+        err.error?.code,
+        err.error?.message,
+        err.details?.code,
+        err.details?.message,
+        err.details?.error?.code,
+        err.details?.error?.message,
+    ].filter(Boolean) as string[];
+
+    return candidates.some(
+        (value) =>
+            value === 'ERR_STREAM_PREMATURE_CLOSE' ||
+            value.includes('Premature close') ||
+            value.includes('ECONNRESET') ||
+            value.includes('socket hang up'),
+    );
+}
+
+async function withRetry<T>(operation: () => Promise<T>, label: string, attempts = 3): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        try {
+            return await operation();
+        } catch (error) {
+            lastError = error;
+            if (!isRetryableAuthError(error) || attempt === attempts) {
+                throw error;
+            }
+            const delayMs = 200 * attempt;
+            console.warn(`⚠️ ${label} failed (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms…`, error);
+            sheetsClientPromise = null;
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+    }
+    throw lastError;
+}
+
+// Initialize Google Sheets API client (shared across requests to avoid OAuth stampedes)
+async function createSheetsClient() {
+    if (!sheetsClientPromise) {
+        sheetsClientPromise = (async () => {
+            try {
+                if (!process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
+                    throw new Error('GOOGLE_SERVICE_ACCOUNT_KEY environment variable is not set');
+                }
+
+                if (!SPREADSHEET_ID) {
+                    throw new Error('GOOGLE_SHEETS_ID environment variable is not set');
+                }
+
+                let credentials;
+                try {
+                    const credentialsString = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+                    const decodedCredentials = atob(credentialsString);
+                    credentials = JSON.parse(decodedCredentials);
+
+                    if (!credentials.client_email || !credentials.private_key || !credentials.project_id) {
+                        throw new Error('Invalid service account credentials - missing required fields');
+                    }
+                } catch (parseError) {
+                    console.error('Failed to parse service account credentials:', parseError);
+                    throw new Error("Invalid GOOGLE_SERVICE_ACCOUNT_KEY format. Ensure it's base64 encoded JSON.");
+                }
+
+                const transporter = {
+                    request: fetchTransporterRequest,
+                };
+
+                const auth = new google.auth.JWT({
+                    email: credentials.client_email,
+                    key: credentials.private_key,
+                    scopes: SCOPES,
+                    transporter,
+                } as ConstructorParameters<typeof google.auth.JWT>[0]);
+
+                // Prefer self-signed JWT access tokens (no token-endpoint round trip)
+                auth.useJWTAccessWithScope = true;
+                auth.transporter = transporter as typeof auth.transporter;
+
+                return google.sheets({ version: 'v4', auth });
+            } catch (error) {
+                sheetsClientPromise = null;
+                console.error('Failed to initialize Google Sheets client:', error);
+                throw error;
+            }
+        })();
+    }
+
+    return sheetsClientPromise;
 }
 
 // Test connection function
@@ -115,16 +259,18 @@ export function createAppError(code: string, message: string, details?: unknown)
  */
 export async function readSheetRange(sheetRange: SheetRange, options: SheetReadOptions = {}): Promise<any[][]> {
     try {
-        const sheetsClient = await createSheetsClient();
-        const response = await sheetsClient.spreadsheets.values.get({
-            spreadsheetId: sheetRange.spreadsheetId,
-            range: sheetRange.range,
-            valueRenderOption: options.valueRenderOption || 'UNFORMATTED_VALUE',
-            dateTimeRenderOption: options.dateTimeRenderOption || 'FORMATTED_STRING',
-            majorDimension: options.majorDimension || 'ROWS',
-        });
+        return await withRetry(async () => {
+            const sheetsClient = await createSheetsClient();
+            const response = await sheetsClient.spreadsheets.values.get({
+                spreadsheetId: sheetRange.spreadsheetId,
+                range: sheetRange.range,
+                valueRenderOption: options.valueRenderOption || 'UNFORMATTED_VALUE',
+                dateTimeRenderOption: options.dateTimeRenderOption || 'FORMATTED_STRING',
+                majorDimension: options.majorDimension || 'ROWS',
+            });
 
-        return response.data.values || [];
+            return response.data.values || [];
+        }, `readSheetRange(${sheetRange.range})`);
     } catch (error) {
         throw createAppError('SHEET_READ_ERROR', `Failed to read sheet range: ${sheetRange.range}`, error);
     }
@@ -139,19 +285,21 @@ export async function writeSheetRange(
     options: SheetWriteOptions = {},
 ): Promise<void> {
     try {
-        const sheetsClient = await createSheetsClient();
-        await sheetsClient.spreadsheets.values.update({
-            spreadsheetId: sheetRange.spreadsheetId,
-            range: sheetRange.range,
-            valueInputOption: options.valueInputOption || 'RAW',
-            includeValuesInResponse: options.includeValuesInResponse || false,
-            responseValueRenderOption: options.responseValueRenderOption || 'FORMATTED_VALUE',
-            responseDateTimeRenderOption: options.responseDateTimeRenderOption || 'FORMATTED_STRING',
-            requestBody: {
-                values,
-                majorDimension: 'ROWS',
-            },
-        });
+        await withRetry(async () => {
+            const sheetsClient = await createSheetsClient();
+            await sheetsClient.spreadsheets.values.update({
+                spreadsheetId: sheetRange.spreadsheetId,
+                range: sheetRange.range,
+                valueInputOption: options.valueInputOption || 'RAW',
+                includeValuesInResponse: options.includeValuesInResponse || false,
+                responseValueRenderOption: options.responseValueRenderOption || 'FORMATTED_VALUE',
+                responseDateTimeRenderOption: options.responseDateTimeRenderOption || 'FORMATTED_STRING',
+                requestBody: {
+                    values,
+                    majorDimension: 'ROWS',
+                },
+            });
+        }, `writeSheetRange(${sheetRange.range})`);
     } catch (error) {
         throw createAppError('SHEET_WRITE_ERROR', `Failed to write to sheet range: ${sheetRange.range}`, error);
     }
@@ -166,20 +314,22 @@ export async function appendToSheet(
     options: SheetWriteOptions = {},
 ): Promise<void> {
     try {
-        const sheetsClient = await createSheetsClient();
-        await sheetsClient.spreadsheets.values.append({
-            spreadsheetId: sheetRange.spreadsheetId,
-            range: sheetRange.range,
-            valueInputOption: options.valueInputOption || 'RAW',
-            insertDataOption: options.insertDataOption || 'INSERT_ROWS',
-            includeValuesInResponse: options.includeValuesInResponse || false,
-            responseValueRenderOption: options.responseValueRenderOption || 'FORMATTED_VALUE',
-            responseDateTimeRenderOption: options.responseDateTimeRenderOption || 'FORMATTED_STRING',
-            requestBody: {
-                values,
-                majorDimension: 'ROWS',
-            },
-        });
+        await withRetry(async () => {
+            const sheetsClient = await createSheetsClient();
+            await sheetsClient.spreadsheets.values.append({
+                spreadsheetId: sheetRange.spreadsheetId,
+                range: sheetRange.range,
+                valueInputOption: options.valueInputOption || 'RAW',
+                insertDataOption: options.insertDataOption || 'INSERT_ROWS',
+                includeValuesInResponse: options.includeValuesInResponse || false,
+                responseValueRenderOption: options.responseValueRenderOption || 'FORMATTED_VALUE',
+                responseDateTimeRenderOption: options.responseDateTimeRenderOption || 'FORMATTED_STRING',
+                requestBody: {
+                    values,
+                    majorDimension: 'ROWS',
+                },
+            });
+        }, `appendToSheet(${sheetRange.range})`);
     } catch (error) {
         throw createAppError('SHEET_APPEND_ERROR', `Failed to append to sheet range: ${sheetRange.range}`, error);
     }
@@ -327,20 +477,22 @@ export async function readSheetWithHeaders(
     options: SheetReadOptions = {},
 ): Promise<{ headers: string[]; data: any[][]; rawData: any[][] }> {
     try {
-        const sheetsClient = await createSheetsClient();
-        const response = await sheetsClient.spreadsheets.values.get({
-            spreadsheetId: sheetRange.spreadsheetId,
-            range: sheetRange.range,
-            valueRenderOption: options.valueRenderOption || 'UNFORMATTED_VALUE',
-            dateTimeRenderOption: options.dateTimeRenderOption || 'FORMATTED_STRING',
-            majorDimension: options.majorDimension || 'ROWS',
-        });
+        return await withRetry(async () => {
+            const sheetsClient = await createSheetsClient();
+            const response = await sheetsClient.spreadsheets.values.get({
+                spreadsheetId: sheetRange.spreadsheetId,
+                range: sheetRange.range,
+                valueRenderOption: options.valueRenderOption || 'UNFORMATTED_VALUE',
+                dateTimeRenderOption: options.dateTimeRenderOption || 'FORMATTED_STRING',
+                majorDimension: options.majorDimension || 'ROWS',
+            });
 
-        const rawData = response.data.values || [];
-        const headers = rawData.length > 0 ? rawData[0] : [];
-        const data = rawData.slice(1);
+            const rawData = response.data.values || [];
+            const headers = rawData.length > 0 ? rawData[0] : [];
+            const data = rawData.slice(1);
 
-        return { headers, data, rawData };
+            return { headers, data, rawData };
+        }, `readSheetWithHeaders(${sheetRange.range})`);
     } catch (error) {
         throw createAppError(
             'SHEET_READ_WITH_HEADERS_ERROR',

--- a/draft/app/admin/admin.route.tsx
+++ b/draft/app/admin/admin.route.tsx
@@ -49,10 +49,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         orchestrator.getSharedContext(),
     ]);
 
-    // Load transfer-specific data if we're on a transfer route or need comprehensive data
+    // Load transfer-specific data only on the transfers admin page (heavy validation)
     let transfersData: Record<string, TransferAdminOverviewData> | null = null;
 
-    const isTransferRoute = url.pathname.includes('/admin/transfers') || url.pathname === '/admin';
+    const isTransferRoute = url.pathname.includes('/admin/transfers');
 
     if (isTransferRoute) {
         const { getTransfersAdminData } = await import('./server/transfers-admin.server');

--- a/draft/app/admin/server/services/admin-orchestrator.service.ts
+++ b/draft/app/admin/server/services/admin-orchestrator.service.ts
@@ -39,15 +39,22 @@ export class AdminOrchestrator {
             this.loadCacheStatus(),
         ]);
 
-        // Load draft sync comparisons for all divisions
-        let draftSyncComparisons = null;
+        // Load draft sync comparisons for all divisions (bounded — Firebase Admin
+        // OAuth can hang on node-fetch "Premature close" and stall the whole admin page)
+        let draftSyncComparisons: Awaited<
+            ReturnType<typeof import('./draft-sync-comparison.service').getAllDraftSyncComparisons>
+        > = [];
         try {
             const { getAllDraftSyncComparisons } = await import('./draft-sync-comparison.service');
-            draftSyncComparisons = await getAllDraftSyncComparisons();
+            draftSyncComparisons = await Promise.race([
+                getAllDraftSyncComparisons(),
+                new Promise<never>((_, reject) =>
+                    setTimeout(() => reject(new Error('Draft sync comparisons timed out')), 12_000),
+                ),
+            ]);
             console.log(`✅ Loaded draft sync comparisons for ${draftSyncComparisons.length} divisions`);
         } catch (error) {
             console.error('❌ Failed to load draft sync comparisons:', error);
-            // Don't fail the whole context load if sync comparisons fail
             draftSyncComparisons = [];
         }
 


### PR DESCRIPTION
## Summary
- Use a shared Sheets client with native `fetch` transport + retries so gaxios/`node-fetch` `ERR_STREAM_PREMATURE_CLOSE` no longer 500s dashboard/admin loaders.
- Make `getCacheStatus` fail-soft (single elements load, 15s timeouts) and bound draft-sync comparisons so Firebase Admin OAuth flakes cannot hang `/admin`.
- Skip heavy `transfersData` loading on the admin overview; only load it on `/admin/transfers`.

## Test plan
- [ ] Hard-refresh `/` — no “Failed to load dashboard data”
- [ ] Hard-refresh `/admin` — Admin Dashboard + System Health render (draft sync may be empty if Firebase OAuth is flaky)
- [ ] Open `/admin/transfers` — transfers data still loads
- [ ] Confirm server logs show draft-sync timeout (if any) without crashing the page


Made with [Cursor](https://cursor.com)