### PR TITLE
Surface Cache + Data action feedback above debug output

### DIFF
--- a/draft/app/admin/components/sections/cache-management-section.tsx
+++ b/draft/app/admin/components/sections/cache-management-section.tsx
@@ -87,6 +87,12 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                 </AdminGrid>
             </AdminSection>
 
+            {/* Action Messages — above debug so feedback is visible without scrolling */}
+            {actionData?.success && actionData.message && (
+                <AdminMessage type="success">{actionData.message}</AdminMessage>
+            )}
+            {actionData?.error && <AdminMessage type="error">{actionData.error}</AdminMessage>}
+
             {/* Debug Information */}
             <AdminSection
                 title="Debug Information"
@@ -139,12 +145,6 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                     </div>
                 </div>
             </AdminSection>
-
-            {/* Action Messages */}
-            {actionData?.success && actionData.message && (
-                <AdminMessage type="success">{actionData.message}</AdminMessage>
-            )}
-            {actionData?.error && <AdminMessage type="error">{actionData.error}</AdminMessage>}
         </AdminContainer>
     );
 }


### PR DESCRIPTION
## Summary
- Move Admin success/error messages on Cache + Data to sit directly under the action buttons, above Debug Information
- Makes Reset Database / Invalidate All Caches completion visible without scrolling

## Test plan
- [ ] Open `/admin/settings`
- [ ] Run Invalidate All Caches or Reset Database
- [ ] Confirm success/error message appears under the buttons without scrolling past debug output