### PR TITLE
Add Admin Setup New Season checklist

### DIFF
--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -160,6 +160,7 @@ Example rules:
 | `/admin/draft` | `admin/admin-draft.route.tsx` | Draft management |
 | `/admin/points` | `admin/admin-points.route.tsx` | Points processing |
 | `/admin/transfers` | `admin/admin-transfers.route.tsx` | Transfer approval |
+| `/admin/setup-new-season` | `admin/admin-setup-new-season.route.tsx` | Season rollover checklist |
 | `/scoring/api/gw-points` | `scoring/api/api.gw-points.ts` | Gameweek points API |
 | `/api/transfers/:divisionId` | `api/transfers/api.transfers.ts` | Transfers data API |
 | `/api/cache` | `api/cache/api.cache.ts` | Cache management API |

--- a/SEASON_CHECKLIST.md
+++ b/SEASON_CHECKLIST.md
@@ -1,0 +1,7 @@
+# Season Checklist (Admins)
+
+The live checklist for rolling into a new season lives in the Admin UI:
+
+**[Admin → Setup New Season](/admin/setup-new-season)** (`/admin/setup-new-season`)
+
+That page is the source of truth for other admins. Keep this file only as a pointer so the markdown copy does not drift.

--- a/draft/app/admin/admin-setup-new-season.route.tsx
+++ b/draft/app/admin/admin-setup-new-season.route.tsx
@@ -1,0 +1,7 @@
+/* Location: app/admin/admin-setup-new-season.route.tsx */
+
+import { SetupNewSeasonSection } from './components/sections/setup-new-season-section';
+
+export default function AdminSetupNewSeasonRoute() {
+    return <SetupNewSeasonSection />;
+}

--- a/draft/app/admin/admin.layout.tsx
+++ b/draft/app/admin/admin.layout.tsx
@@ -47,6 +47,12 @@ const navigationItems: AdminNavItem[] = [
         icon: <Icons.CloudIcon />,
         path: '/admin/settings',
     },
+    {
+        key: 'setupNewSeason',
+        label: 'Setup New Season',
+        icon: <Icons.CalendarIcon />,
+        path: '/admin/setup-new-season',
+    },
 ];
 
 export const AdminLayout: React.FC<AdminDashboardLayoutProps> = ({ children }) => {
@@ -59,6 +65,7 @@ export const AdminLayout: React.FC<AdminDashboardLayoutProps> = ({ children }) =
         if (path.startsWith('/admin/transfers')) return 'transfers';
         if (path.startsWith('/admin/points')) return 'points';
         if (path.startsWith('/admin/settings')) return 'settings';
+        if (path.startsWith('/admin/setup-new-season')) return 'setupNewSeason';
         return 'overview';
     };
 

--- a/draft/app/admin/admin.route.tsx
+++ b/draft/app/admin/admin.route.tsx
@@ -27,8 +27,8 @@ export const meta: MetaFunction = () => {
 };
 
 interface AdminLoaderData {
-    systemStatus: SystemStatusSummary;
-    sharedContext: AdminDataContext;
+    systemStatus: SystemStatusSummary | null;
+    sharedContext: AdminDataContext | null;
     transfersData: Record<string, TransferAdminOverviewData> | null;
     teamsByCode: Record<number, FplTeam> | null;
     cacheStats: any | null;
@@ -37,6 +37,20 @@ interface AdminLoaderData {
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
+
+    // Static checklist page — skip FPL/Sheets/Firebase bootstrap
+    if (url.pathname.includes('/admin/setup-new-season')) {
+        console.log('⚡ Lightweight admin load for setup-new-season');
+        return {
+            systemStatus: null,
+            sharedContext: null,
+            transfersData: null,
+            teamsByCode: null,
+            cacheStats: null,
+            loadedAt: new Date().toISOString(),
+        };
+    }
+
     console.log('🔄 Loading admin dashboard data...');
 
     const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
@@ -69,6 +83,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         sharedContext,
         transfersData,
         teamsByCode,
+        cacheStats: null,
         loadedAt: new Date().toISOString(),
     };
 }

--- a/draft/app/admin/components/icons/admin-icons.tsx
+++ b/draft/app/admin/components/icons/admin-icons.tsx
@@ -107,3 +107,14 @@ export const FileIcon = () => (
         />
     </svg>
 );
+
+export const CalendarIcon = () => (
+    <svg style={{ width: '1.25rem', height: '1.25rem' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+        />
+    </svg>
+);

--- a/draft/app/admin/components/sections/setup-new-season-section.module.css
+++ b/draft/app/admin/components/sections/setup-new-season-section.module.css
@@ -1,0 +1,243 @@
+/* Location: app/admin/components/sections/setup-new-season-section.module.css */
+
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-6);
+    max-width: 52rem;
+}
+
+.policyList {
+    margin: 0;
+    padding-left: var(--spacing-5);
+    color: var(--color-gray-600);
+    line-height: 1.6;
+}
+
+.policyItem {
+    margin-bottom: var(--spacing-2);
+}
+
+.policyItem:last-child {
+    margin-bottom: 0;
+}
+
+.warningBox {
+    background: var(--color-warning-light);
+    border: 1px solid var(--color-warning-border);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-4);
+}
+
+.warningHeader {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-warning-text);
+    margin-bottom: var(--spacing-2);
+}
+
+.warningText {
+    color: var(--color-warning-text);
+    margin: 0;
+    line-height: 1.5;
+}
+
+.successBox {
+    background: var(--color-success-light);
+    border: 1px solid var(--color-success-border);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-4);
+}
+
+.successHeader {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-success-text);
+    margin-bottom: var(--spacing-2);
+}
+
+.successText {
+    color: var(--color-success-text);
+    margin: 0;
+    line-height: 1.5;
+}
+
+.steps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-4);
+}
+
+.step {
+    display: flex;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4);
+    background: var(--color-gray-50);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-lg);
+    position: relative;
+}
+
+.step:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: 1.2rem;
+    top: calc(100% + var(--spacing-2));
+    width: 2px;
+    height: var(--spacing-2);
+    background: var(--color-gray-300);
+}
+
+.stepNumber {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    background: var(--color-primary);
+    color: var(--color-white);
+    border-radius: var(--radius-full);
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-sm);
+    flex-shrink: 0;
+}
+
+.stepContent {
+    flex: 1;
+    min-width: 0;
+}
+
+.stepTitle {
+    margin: 0 0 var(--spacing-2) 0;
+    font-size: var(--font-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.stepDescription {
+    margin: 0 0 var(--spacing-3) 0;
+    color: var(--color-gray-600);
+    line-height: 1.5;
+}
+
+.stepList {
+    margin: 0 0 var(--spacing-3) 0;
+    padding-left: var(--spacing-5);
+    color: var(--color-gray-600);
+}
+
+.stepListItem {
+    margin-bottom: var(--spacing-2);
+    line-height: 1.5;
+}
+
+.stepListItem:last-child {
+    margin-bottom: 0;
+}
+
+.stepNote {
+    background: var(--color-primary-light);
+    border: 1px solid var(--color-info-border);
+    border-radius: var(--radius-sm);
+    padding: var(--spacing-2);
+    font-size: var(--font-sm);
+    color: var(--color-position-mid-text);
+    font-style: italic;
+    margin-top: var(--spacing-3);
+}
+
+.inlineLink {
+    color: var(--color-primary);
+    font-weight: var(--font-weight-medium);
+    text-decoration: underline;
+}
+
+.inlineLink:hover {
+    color: var(--color-primary-hover);
+}
+
+.tableWrap {
+    overflow-x: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-sm);
+}
+
+.tableHeaderCell {
+    text-align: left;
+    padding: var(--spacing-2) var(--spacing-3);
+    background: var(--color-gray-50);
+    border-bottom: 1px solid var(--color-gray-200);
+    color: var(--color-gray-700);
+    font-weight: var(--font-weight-semibold);
+}
+
+.tableCell {
+    padding: var(--spacing-2) var(--spacing-3);
+    border-bottom: 1px solid var(--color-gray-200);
+    color: var(--color-gray-600);
+    vertical-align: top;
+    line-height: 1.45;
+}
+
+.tableCode {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: var(--font-xs);
+    background: var(--color-gray-100);
+    padding: 0.1rem var(--spacing-1);
+    border-radius: var(--radius-sm);
+    color: var(--color-gray-800);
+    white-space: nowrap;
+}
+
+.checklist {
+    margin: 0;
+    padding-left: var(--spacing-5);
+    color: var(--color-gray-600);
+    line-height: 1.6;
+}
+
+.checklistItem {
+    margin-bottom: var(--spacing-2);
+}
+
+.checklistItem:last-child {
+    margin-bottom: 0;
+}
+
+.avoidList {
+    margin: 0;
+    padding-left: var(--spacing-5);
+    color: var(--color-gray-600);
+    line-height: 1.6;
+}
+
+.avoidItem {
+    margin-bottom: var(--spacing-2);
+}
+
+.avoidItem:last-child {
+    margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+    .step {
+        flex-direction: column;
+        gap: var(--spacing-3);
+    }
+
+    .step:not(:last-child)::after {
+        display: none;
+    }
+
+    .stepNumber {
+        align-self: flex-start;
+    }
+}

--- a/draft/app/admin/components/sections/setup-new-season-section.tsx
+++ b/draft/app/admin/components/sections/setup-new-season-section.tsx
@@ -1,0 +1,312 @@
+/* Location: app/admin/components/sections/setup-new-season-section.tsx */
+
+import { Link } from 'react-router';
+import * as Icons from '../icons/admin-icons';
+import { AdminContainer } from '../layout/admin-container';
+import { AdminSection } from '../layout/admin-section';
+import styles from './setup-new-season-section.module.css';
+
+const CLEAR_TABS = [
+    { tab: 'Draft', action: 'Delete all pick rows (keep headers)' },
+    { tab: 'DraftState', action: 'Reset to inactive: no current user/pick; clear start/end dates' },
+    { tab: 'DraftOrder', action: 'Clear or replace with the new season\'s draft order once known' },
+    { tab: 'premierLeague-transfers', action: 'Delete all transfer rows' },
+    { tab: 'championship-transfers', action: 'Delete all transfer rows' },
+    { tab: 'leagueOne-transfers', action: 'Delete all transfer rows' },
+    { tab: 'Cup', action: 'Delete all submission rows' },
+    { tab: 'CupBracket', action: 'Delete all bracket rows' },
+    { tab: 'player-gw-points', action: 'Delete all data rows' },
+] as const;
+
+const UPDATE_TABS = [
+    { tab: 'Divisions', action: 'Confirm the three divisions are correct (rarely needs change)' },
+    {
+        tab: 'UserTeams',
+        action: 'Apply promotion/relegation; add/remove managers; fix team names, user IDs, division assignments',
+    },
+    {
+        tab: 'Players',
+        action: 'Refresh the draft pool for the new PL season (codes, positions, hidden flags). Re-apply new flags as needed',
+    },
+    {
+        tab: 'CupConfig',
+        action: 'Update season (e.g. 2627) and gameweek mappings for league / knockout stages when known',
+    },
+] as const;
+
+export function SetupNewSeasonSection() {
+    return (
+        <AdminContainer>
+            <AdminSection
+                title="Setup New Season"
+                icon={<Icons.CalendarIcon />}
+                description="Step-by-step checklist to roll the site into a new season. Follow these steps in order."
+            >
+                <div className={styles.container}>
+                    <div className={styles.warningBox}>
+                        <div className={styles.warningHeader}>
+                            <Icons.AlertIcon />
+                            <span>Policy</span>
+                        </div>
+                        <ul className={styles.policyList}>
+                            <li className={styles.policyItem}>
+                                <strong>Reuse the same live Google Sheet</strong> for the website. Do not change{' '}
+                                <span className={styles.tableCode}>GOOGLE_SHEETS_ID</span> or redeploy for a new
+                                spreadsheet.
+                            </li>
+                            <li className={styles.policyItem}>
+                                <strong>Clone the sheet first</strong> as a historic archive (put the season in that
+                                copy's title, e.g. Draft FF 25/26).
+                            </li>
+                            <li className={styles.policyItem}>
+                                <strong>Do not rename tabs</strong> (Draft, UserTeams, premierLeague-transfers, etc.) —
+                                those names are required by the app.
+                            </li>
+                        </ul>
+                        <p className={styles.warningText}>
+                            Rosters are rebuilt from draft picks + transfers into Firebase/Firestore. Old Firebase data
+                            is not cleared by cloning the sheet — a database/cache reset is still required.
+                        </p>
+                    </div>
+
+                    <div className={styles.steps}>
+                        <div className={styles.step}>
+                            <div className={styles.stepNumber}>1</div>
+                            <div className={styles.stepContent}>
+                                <h3 className={styles.stepTitle}>Archive last season</h3>
+                                <ol className={styles.stepList}>
+                                    <li className={styles.stepListItem}>Open the live Google Sheet.</li>
+                                    <li className={styles.stepListItem}>
+                                        <strong>File → Make a copy</strong>.
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Name the copy with the season, e.g. Draft FF 25/26 (archive).
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Leave that copy alone — it is the historic record. Do not point the website at
+                                        it.
+                                    </li>
+                                </ol>
+                            </div>
+                        </div>
+
+                        <div className={styles.step}>
+                            <div className={styles.stepNumber}>2</div>
+                            <div className={styles.stepContent}>
+                                <h3 className={styles.stepTitle}>Clear transactional data on the live sheet</h3>
+                                <p className={styles.stepDescription}>
+                                    Delete <strong>data rows</strong> on these tabs. <strong>Keep the header row</strong>{' '}
+                                    on each.
+                                </p>
+                                <div className={styles.tableWrap}>
+                                    <table className={styles.table}>
+                                        <thead>
+                                            <tr>
+                                                <th className={styles.tableHeaderCell}>Tab</th>
+                                                <th className={styles.tableHeaderCell}>What to do</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {CLEAR_TABS.map((row) => (
+                                                <tr key={row.tab}>
+                                                    <td className={styles.tableCell}>
+                                                        <span className={styles.tableCode}>{row.tab}</span>
+                                                    </td>
+                                                    <td className={styles.tableCell}>{row.action}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div className={styles.stepNote}>
+                                    Leftover approved transfers or draft picks will be applied when the new season
+                                    rebuilds team docs. A missed clear here is the main way a reused sheet corrupts the
+                                    new season.
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className={styles.step}>
+                            <div className={styles.stepNumber}>3</div>
+                            <div className={styles.stepContent}>
+                                <h3 className={styles.stepTitle}>Update league / player setup</h3>
+                                <p className={styles.stepDescription}>
+                                    These tabs are usually <strong>edited</strong>, not emptied.
+                                </p>
+                                <div className={styles.tableWrap}>
+                                    <table className={styles.table}>
+                                        <thead>
+                                            <tr>
+                                                <th className={styles.tableHeaderCell}>Tab</th>
+                                                <th className={styles.tableHeaderCell}>What to do</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {UPDATE_TABS.map((row) => (
+                                                <tr key={row.tab}>
+                                                    <td className={styles.tableCell}>
+                                                        <span className={styles.tableCode}>{row.tab}</span>
+                                                    </td>
+                                                    <td className={styles.tableCell}>{row.action}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className={styles.step}>
+                            <div className={styles.stepNumber}>4</div>
+                            <div className={styles.stepContent}>
+                                <h3 className={styles.stepTitle}>Reset Firebase / Firestore + caches</h3>
+                                <p className={styles.stepDescription}>
+                                    Old gameweek team docs are not keyed by season. Clear them even though the Google
+                                    Sheet ID is unchanged.
+                                </p>
+                                <ol className={styles.stepList}>
+                                    <li className={styles.stepListItem}>
+                                        Go to{' '}
+                                        <Link className={styles.inlineLink} to="/admin/settings">
+                                            Cache + Data
+                                        </Link>
+                                        .
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Click <strong>Reset Database</strong> and confirm when prompted.
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Click <strong>Invalidate All Caches</strong>.
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Go to{' '}
+                                        <Link className={styles.inlineLink} to="/admin/draft">
+                                            Draft Management
+                                        </Link>{' '}
+                                        and click <strong>Sync</strong> for each division so Firebase matches the
+                                        cleared sheets.
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Confirm draft status looks empty / inactive before starting anything.
+                                    </li>
+                                </ol>
+                            </div>
+                        </div>
+
+                        <div className={styles.step}>
+                            <div className={styles.stepNumber}>5</div>
+                            <div className={styles.stepContent}>
+                                <h3 className={styles.stepTitle}>Run the new season draft</h3>
+                                <ol className={styles.stepList}>
+                                    <li className={styles.stepListItem}>
+                                        Confirm <span className={styles.tableCode}>DraftOrder</span> is correct for each
+                                        division.
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        <strong>Start Draft</strong> per division from{' '}
+                                        <Link className={styles.inlineLink} to="/admin/draft">
+                                            Draft Management
+                                        </Link>
+                                        .
+                                    </li>
+                                    <li className={styles.stepListItem}>Run the draft as usual.</li>
+                                    <li className={styles.stepListItem}>
+                                        After a division completes, <strong>commit teams</strong> to Firestore if
+                                        auto-commit did not run.
+                                    </li>
+                                    <li className={styles.stepListItem}>
+                                        Invalidate caches once more if the site still shows stale draft/team data.
+                                    </li>
+                                </ol>
+                            </div>
+                        </div>
+
+                        <div className={styles.step}>
+                            <div className={styles.stepNumber}>6</div>
+                            <div className={styles.stepContent}>
+                                <h3 className={styles.stepTitle}>Smoke checks before going live</h3>
+                                <ul className={styles.checklist}>
+                                    <li className={styles.checklistItem}>
+                                        Archive copy exists and is clearly named with the old season
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        Spreadsheet URL/ID unchanged (still the live sheet, not the archive)
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        Transfer tabs are empty (headers only)
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        Draft empty; DraftState inactive until you start
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        UserTeams divisions match promotion/relegation
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        Players list looks right for the new PL season
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        Admin system health can talk to Google Sheets
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        No last-season standings / rosters visible after cache reset
+                                    </li>
+                                    <li className={styles.checklistItem}>
+                                        Draft start works for one division in a dry run if needed
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className={styles.successBox}>
+                        <div className={styles.successHeader}>
+                            <Icons.CheckIcon />
+                            <span>What you do not need to do</span>
+                        </div>
+                        <ul className={styles.avoidList}>
+                            <li className={styles.avoidItem}>Create a brand-new Google Sheet for the website</li>
+                            <li className={styles.avoidItem}>
+                                Change <span className={styles.tableCode}>GOOGLE_SHEETS_ID</span> in env, Firebase, or
+                                GitHub secrets
+                            </li>
+                            <li className={styles.avoidItem}>Redeploy solely because of a season rollover</li>
+                            <li className={styles.avoidItem}>
+                                Re-share the sheet with the service account (same file keeps existing access)
+                            </li>
+                            <li className={styles.avoidItem}>Rename any tabs</li>
+                        </ul>
+                    </div>
+                </div>
+            </AdminSection>
+
+            <AdminSection
+                title="If something looks wrong"
+                icon={<Icons.AlertIcon />}
+                description="Quick recovery checks when last-season data still appears."
+            >
+                <ol className={styles.stepList}>
+                    <li className={styles.stepListItem}>
+                        Confirm you're editing the <strong>live</strong> sheet, not the archive copy.
+                    </li>
+                    <li className={styles.stepListItem}>Re-check transfer / draft tabs for leftover rows.</li>
+                    <li className={styles.stepListItem}>
+                        <Link className={styles.inlineLink} to="/admin/settings">
+                            Cache + Data
+                        </Link>{' '}
+                        → <strong>Invalidate All Caches</strong>.
+                    </li>
+                    <li className={styles.stepListItem}>
+                        <Link className={styles.inlineLink} to="/admin/draft">
+                            Draft Management
+                        </Link>{' '}
+                        → <strong>Sync</strong> for the affected division.
+                    </li>
+                    <li className={styles.stepListItem}>
+                        If team pages still show last season, confirm <strong>Reset Database</strong> was run — sheet-only
+                        clears are not enough.
+                    </li>
+                </ol>
+            </AdminSection>
+        </AdminContainer>
+    );
+}

--- a/draft/app/admin/types/admin-types.ts
+++ b/draft/app/admin/types/admin-types.ts
@@ -20,7 +20,7 @@ export interface AdminDashboardData {
 // ADMIN NAVIGATION TYPES
 // ==========================================
 
-type AdminSectionKey = 'overview' | 'draft' | 'transfers' | 'points' | 'settings';
+type AdminSectionKey = 'overview' | 'draft' | 'transfers' | 'points' | 'settings' | 'setupNewSeason';
 
 export interface AdminNavItem {
     key: AdminSectionKey;

--- a/draft/app/routes.ts
+++ b/draft/app/routes.ts
@@ -42,6 +42,7 @@ export default [
         route('draft', 'admin/admin-draft.route.tsx'),
         route('points', 'admin/admin-points.route.tsx'),
         route('settings', 'admin/admin-settings.route.tsx'),
+        route('setup-new-season', 'admin/admin-setup-new-season.route.tsx'),
         route('transfers', 'admin/admin-transfers.route.tsx'),
     ]),
 


### PR DESCRIPTION
## Summary
- Add **Admin → Setup New Season** (`/admin/setup-new-season`) with the agreed season rollover checklist (reuse live sheet, archive via clone, clear transactional tabs, reset Firestore/caches, draft)
- Skip the parent admin loader’s FPL/Sheets/Firebase bootstrap on that route so the static page stays fast
- Point `SEASON_CHECKLIST.md` at the admin page as the source of truth

## Test plan
- [ ] Open `/admin/setup-new-season` — page loads quickly without waiting on Sheets/draft sync
- [ ] Confirm nav item **Setup New Season** highlights correctly
- [ ] Spot-check checklist content (policy, clear/update tabs, Cache + Data / Draft links)
- [ ] Other admin pages (`/admin`, `/admin/draft`, `/admin/settings`) still load shared context as before