### PR TITLE
fix(players): show our own defensive actions in the DC cell

### DIFF
--- a/draft/app/players/components/player-gameweek-table.test.tsx
+++ b/draft/app/players/components/player-gameweek-table.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 /* Location: app/players/components/player-gameweek-table.test.tsx */
 
-import { render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { CustomPosition } from '../../_shared/types/league-types';
 import type { GameweekStatWithPoints } from '../../scoring/types/scoring-types';
@@ -239,6 +239,41 @@ describe('PlayerGameweekTable stat tooltips', () => {
         renderTable('mid', [makeGameweek({ bonus: 1 })]);
 
         expect(tooltipOf('Bonus')).toBe('1 points');
+    });
+});
+
+describe('PlayerGameweekTable defensive contribution cell', () => {
+    // The cell and the tooltip are two halves of one claim: "you did N actions, that was
+    // worth P points". They must be computed the same way, or the column contradicts
+    // itself. 6fca9d7 moved the points onto the raw components and left the cell showing
+    // FPL's aggregate, which is keyed to FPL's position rather than ours.
+    it('shows the actions the tooltip’s points were calculated from', () => {
+        renderTable('mid', [makeGameweek({ clearancesBlocksInterceptions: 7, tackles: 4, recoveries: 1 })]);
+
+        expect(cell('DC').textContent).toBe('12'); // 7 + 4 + 1, the number compared to the threshold
+        expect(tooltipOf('DC')).toBe('2 points');
+    });
+
+    // The same match read against two positions: a defender's metric excludes
+    // recoveries, so the cell itself must differ, not just the points.
+    it('counts recoveries for a midfielder but not a defender', () => {
+        const MATCH = { clearancesBlocksInterceptions: 6, tackles: 4, recoveries: 5 };
+
+        renderTable('mid', [makeGameweek(MATCH)]);
+        expect(cell('DC').textContent).toBe('15'); // 6 + 4 + 5
+        cleanup();
+
+        renderTable('cb', [makeGameweek(MATCH)]);
+        expect(cell('DC').textContent).toBe('10'); // 6 + 4, recoveries excluded
+    });
+
+    // FPL's aggregate is still carried on the stat object. Nothing may read it: here it
+    // is set to a value that contradicts the components, and the cell must ignore it.
+    it('ignores FPL’s aggregate when it disagrees with the raw components', () => {
+        renderTable('cb', [makeGameweek({ defensiveContribution: 99, clearancesBlocksInterceptions: 6, tackles: 4 })]);
+
+        expect(cell('DC').textContent).toBe('10'); // 6 + 4, not 99
+        expect(tooltipOf('DC')).toBe('1 points');
     });
 });
 

--- a/draft/app/players/components/player-gameweek-table.tsx
+++ b/draft/app/players/components/player-gameweek-table.tsx
@@ -3,6 +3,7 @@
 import { Table, TableBadge, type TableColumn } from '../../_shared/components/table';
 import type { CustomPosition } from '../../_shared/types/league-types';
 import { calculateGameweekPoints, formatPointsDisplay, isStatRelevant } from '../../scoring/lib';
+import { calculateDefensiveActions } from '../../scoring/lib/calculations';
 import { convertToGameweekStats } from '../../scoring/lib/data-conversion';
 import type { GameweekStatWithPoints } from '../../scoring/types/scoring-types';
 
@@ -206,16 +207,19 @@ export function PlayerGameweekTable({ gameweekStats, position, currentGameweek }
             render: (bonus) => getStatDisplay(bonus, 'bonus', position),
         });
     }
-    // Add bonus if relevant
+    // The cell counts the defensive actions OUR position cares about -- CBIT for
+    // defenders, CBIRT for midfielders -- so the number shown is the one the threshold in
+    // the tooltip was applied to. It deliberately ignores `stat.defensiveContribution`,
+    // which is FPL's aggregate, keyed to FPL's position rather than ours.
     if (isStatRelevant('defensiveContribution', position)) {
         columns.push({
             key: 'defensiveContribution',
             header: 'DC',
-            accessor: 'defensiveContribution',
             align: 'center',
             width: 60,
             title: (stat) => `${pointsFor(stat).defensiveContribution} points`,
-            render: (dc) => getStatDisplay(dc, 'defensiveContribution', position),
+            render: (_, stat) =>
+                getStatDisplay(calculateDefensiveActions(stat, position), 'defensiveContribution', position),
         });
     }
 

--- a/draft/app/scoring/lib/calculations.test.ts
+++ b/draft/app/scoring/lib/calculations.test.ts
@@ -3,6 +3,7 @@ import type { FplPlayerGameweekData } from '../../_shared/lib/fpl/fpl-types';
 import type { CustomPosition } from '../../_shared/types/league-types';
 import {
     calculateBonus,
+    calculateDefensiveActions,
     calculateDefensiveContribution,
     calculateGameweekPoints,
     calculateGoalsConcededPenalty,
@@ -64,6 +65,37 @@ describe('calculateDefensiveContribution', () => {
         expect(calculateDefensiveContribution(raw(20, 20, 20), 'gk')).toBe(0);
         expect(calculateDefensiveContribution(raw(20, 20, 20), 'wa')).toBe(0);
         expect(calculateDefensiveContribution(raw(20, 20, 20), 'ca')).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// calculateDefensiveActions
+// ---------------------------------------------------------------------------
+
+// The DC *stat* -- the number the threshold is tested against, and the number the DC
+// column shows. It is position-dependent for exactly the same reason the points are:
+// a defender's metric excludes recoveries, a midfielder's includes them. FPL's
+// `defensive_contribution` aggregate is keyed to FPL's position and is not used.
+describe('calculateDefensiveActions', () => {
+    // The same match yields a different DC stat depending on our position, which is why
+    // the cell cannot just display a stored number.
+    it('counts CBIT for a defender and CBIRT for a midfielder', () => {
+        expect(calculateDefensiveActions(raw(6, 4, 5), 'cb')).toBe(10); // 6 + 4, recoveries excluded
+        expect(calculateDefensiveActions(raw(6, 4, 5), 'fb')).toBe(10); // 6 + 4, recoveries excluded
+        expect(calculateDefensiveActions(raw(6, 4, 5), 'mid')).toBe(15); // 6 + 4 + 5
+    });
+
+    // The property that matters: the stat and the points must agree about the threshold.
+    it('is the number the threshold is applied to', () => {
+        expect(calculateDefensiveActions(raw(5, 5, 0), 'cb')).toBe(10);
+        expect(calculateDefensiveContribution(raw(5, 5, 0), 'cb')).toBe(1); // 10 >= 10
+
+        expect(calculateDefensiveActions(raw(5, 4, 0), 'cb')).toBe(9);
+        expect(calculateDefensiveContribution(raw(5, 4, 0), 'cb')).toBe(0); // 9 < 10
+    });
+
+    it('counts nothing when the player did nothing defensive', () => {
+        expect(calculateDefensiveActions(raw(0, 0, 0), 'mid')).toBe(0);
     });
 });
 

--- a/draft/app/scoring/lib/calculations.ts
+++ b/draft/app/scoring/lib/calculations.ts
@@ -21,27 +21,38 @@ const baselineStats: Points = {
     total: 0,
 };
 
+/** The raw components behind the defensive-contribution metric. */
+export type DefensiveComponents = Pick<
+    PlayerGameweekStatsData,
+    'clearancesBlocksInterceptions' | 'tackles' | 'recoveries'
+>;
+
 /**
- * Calculate defensive-contribution points from the raw components, using OUR custom
- * position to decide the metric: CBIT (clearances+blocks+interceptions+tackles) for
- * defenders, CBIRT (+ recoveries) for midfielders. We do NOT use FPL's aggregate
- * `defensive_contribution`, which bakes in FPL's own position and is wrong whenever
- * our position disagrees with FPL's (e.g. Matheus Nunes).
+ * Count a match's defensive actions, using OUR custom position to decide the metric:
+ * CBIT (clearances+blocks+interceptions+tackles) for defenders, CBIRT (+ recoveries)
+ * for midfielders.
+ *
+ * This is the number the threshold is applied to, so it is also the number the DC
+ * column should show. We do NOT use FPL's aggregate `defensive_contribution`, which
+ * bakes in FPL's own position and is wrong whenever our position disagrees with FPL's
+ * (e.g. Matheus Nunes).
  *
  * Only cb, fb and mid have a defensive-contribution rule, so mid is the only position
  * that counts recoveries. If wa/ca ever gain a rule, revisit whether they should too.
  */
-export function calculateDefensiveContribution(
-    stats: Pick<PlayerGameweekStatsData, 'clearancesBlocksInterceptions' | 'tackles' | 'recoveries'>,
-    position: CustomPosition,
-): number {
+export function calculateDefensiveActions(stats: DefensiveComponents, position: CustomPosition): number {
+    const cbit = (stats.clearancesBlocksInterceptions || 0) + (stats.tackles || 0);
+    return position === 'mid' ? cbit + (stats.recoveries || 0) : cbit;
+}
+
+/**
+ * Calculate defensive-contribution points for a single match.
+ */
+export function calculateDefensiveContribution(stats: DefensiveComponents, position: CustomPosition): number {
     const rule = POSITION_RULES[position];
     if (!('defensiveContribution' in rule)) return 0;
 
-    const cbit = (stats.clearancesBlocksInterceptions || 0) + (stats.tackles || 0);
-    const total = position === 'mid' ? cbit + (stats.recoveries || 0) : cbit;
-
-    if (total < rule.defensiveContribution.threshold) return 0;
+    if (calculateDefensiveActions(stats, position) < rule.defensiveContribution.threshold) return 0;
     return rule.defensiveContribution.points;
 }
 /**


### PR DESCRIPTION
6fca9d7 moved the defensive-contribution POINTS onto the raw components (CBIT for cb/fb, CBIRT for mid) keyed off our custom position, which was correct. It left the displayed stat as FPL's `defensive_contribution` aggregate, which is keyed off FPL's position.

So since that commit the DC column has contradicted itself: the tooltip computes from the components, the cell shows FPL's number. For a player we classify differently from FPL (the Matheus Nunes case named in the original commit) the cell can read 8 next to a tooltip saying "1 points", against a threshold of 10.

Verified what FPL's field actually holds, against 2025/26 season data: it is a raw action count, not points, and it is CBIT for DEF, CBIRT for MID/FWD, 0 for GKP. So wherever our position agrees with FPL's the two numbers are identical -- which is why this looked right and survived.

Extracts `calculateDefensiveActions` (the count the threshold is applied to) and renders it in the cell, so both halves of the column come from one calculation. No points change: the tooltip, the Points column and every stored score are untouched.

This completes the gameweek half only. The season DC columns still sum FPL's per-match aggregates -- Gabriel reads 277 against a per-match threshold of 10 -- which is wrong for every player and needs a stored-shape change and a data migration. Tracked as an open decision in #99.