### PR TITLE
test(draft): cover the snake order, next picker and draft rules

### DIFF
--- a/.kiro/backlog.md
+++ b/.kiro/backlog.md
@@ -28,9 +28,11 @@ git log --oneline -15
 
 | | Why |
 |---|---|
-| **P2.7 — public API for `draft`** | Unblocks moving `firebase-draft-sync.ts` into the domain and removes the allowlist entry P2.3 had to add. Makes Rule 2 real rather than aspirational. |
+| **P2.7 — public API for `draft`** | Unblocks moving `firebase-draft-sync.ts` into the domain and removes the allowlist entry P2.3 had to add. Makes Rule 2 real rather than aspirational. **`draft/lib/` is now covered by P3.3**, so the restructure has tests holding it in place — do it in that order. |
 | **P2.3 — remaining sheets readers** | `transfers.ts`, `cup.ts`, `player-gw-points.ts`. `draft.ts` is done and is the worked example to copy. |
-| **P3.3 / P3.4 — draft order + loader tests** | P3.4 is blocked on P2.3 giving it an injection seam. |
+| **P3.4 — first loader test** | Blocked on P2.3 giving it an injection seam. Also inherits the duplicate-pick rule P3.3 could not reach. |
+
+*Recently done: P4.5 (steering doc back in line with reality, plus a drift check), P3.3 (draft/lib now has 47 tests).*
 
 **Working agreements that are not obvious from the code:**
 - Consumer-focused tests that survive refactoring come **before** the refactor they protect. We violated this early and it cost us.
@@ -101,7 +103,7 @@ Re-measure with `yarn ratchet` and `yarn test`. Committed counts live in `.ratch
 | Type errors | 275 | **177** |
 | CSS convention violations | not measurable (stylelint not installed) | **175** — `color-no-hex` cleared |
 | Biome lint warnings | 280, none enforced | **266**, ratcheted |
-| Tests | 149 passing, 24 files | **249 passing, 28 files** |
+| Tests | 149 passing, 24 files | **296 passing, 32 files** |
 | CI type check | `continue-on-error: true` — cannot fail a PR | ratcheted, blocking |
 | Root `yarn type-check` | fails: `command not found: tsc` | works |
 | Pre-commit hook | never ran (see P0.6) | runs lint-staged + tests |
@@ -412,12 +414,26 @@ Ordered by risk. The existing tests are good — this is a coverage-placement pr
 - [x] **P3.2 — Cache TTL resolution and invalidation rules**
   *Done during P0.2/P0.3* — 19 tests in [cache-invalidation.test.ts](../draft/app/_shared/lib/cache/cache-invalidation.test.ts). Covers `getCacheTTL` for every key shape (including the `sheets:cup-config` / `sheets:cup` ordering trap and a check that no live key silently falls through to the default), every invalidation rule, and two structural tests asserting no rule is declared without a caller and none is called without being declared.
 
-- [ ] **P3.3 — Draft snake order and next-picker**
-  `draft/lib/` has zero tests. Named explicitly in the testing conventions: snake order generation, and that the same player cannot be picked twice in a division.
-  *Acceptance:* `generate-draft-sequence`, `calculate-next-picker` and `draft-rules` covered, including the even-round reversal.
+- [x] **P3.3 — Draft snake order and next-picker**
+  *Done:* 4 test files, 47 tests; suite **249 → 296**. `draft/lib/` had zero tests despite holding the rule that decides whose turn it is.
+
+  | File | Covers |
+  |---|---|
+  | `generate-draft-sequence.test.ts` | the reversal, the double pick at the turn of a round, continuous pick numbering, equal picks per manager, two-manager and empty edge cases |
+  | `calculate-next-picker.test.ts` | who is "on deck", including the turn where the current picker is also next; end-of-draft; inactive/absent state |
+  | `draft-pick-calculator.test.ts` | division scoping, the snake as the server records it, the empty-string "nobody" signal |
+  | `draft-rules.test.ts` | position maximums, bench overflow, the 2-per-club hard block, unknown positions, full squad |
+
+  **The snake rule is implemented three times** — `generateDraftSequence` (what the draft room shows), `calculateCurrentUserId` (what the server records) and `calculateNextPicker` (the "on deck" badge). If they drift, the room shows one manager's turn while the server accepts a pick from another. There is now a test asserting the first two produce identical picking orders across 2-, 3- and 5-manager drafts.
+
+  **`calculateNextPicker` is deliberately one pick ahead.** It reads `currentPick + 1`, which looks like an off-by-one. It is not: the draft room renders it as "Get Ready..." with an `onDeck` class, i.e. the manager *after* the one currently picking. Confirmed against the component before writing the test, per the rule that a test must never encode a bug.
+
+  *Acceptance:* ✅ all three named modules covered, even-round reversal included.
+  *Not covered:* "the same player cannot be picked twice in a division". That guard is in `draft.server.ts:150`, not `lib/`, and needs the injection seam P3.4 is waiting on. Carried into P3.4.
 
 - [ ] **P3.4 — First route-loader test**
   Named as the priority boundary in the testing conventions, currently impossible because sheets modules are imported directly with no injection seam. **Blocked on P2.3.**
+  *Also carries from P3.3:* the "same player cannot be picked twice in a division" rule, which lives in `draft.server.ts:150` and needs the same seam.
   Establish the pattern once — inject a fake sheets client returning fixtures, assert the loader's returned shape for a given URL and division — then replicate across loaders.
   *Acceptance:* one loader test exists and the pattern is documented in the testing conventions.
 
@@ -489,6 +505,7 @@ Add new issues here as they surface. Do not fix them in the task that found them
 | 2026-07-26 | **[Separate problem found]** | `formatPointsDisplay`'s docstring promised a `+` prefix on positive totals that was never implemented. Adding one changes every points figure in the UI, so it is a product decision rather than a bug fix. Deliberately left alone. | [utils.ts](../draft/app/scoring/lib/utils.ts) |
 | 2026-07-26 | **[Partly fixed — decision open]** | The DC column displayed FPL's `defensive_contribution` aggregate while its tooltip computed points from the raw components against our custom position. **A regression from 6fca9d7**, which fixed the points and left the display behind. Wider than first logged: FPL's aggregate was the only DC stat in the app, shown in five places. **Gameweek half fixed in 3ed52bc**; the season columns still sum per-match counts (Gabriel reads 277 against a per-match threshold) and need a stored-shape change plus a data migration. Open decision in [#99](https://github.com/peter-mouland/kammy-ssg/issues/99). | [calculations.ts](../draft/app/scoring/lib/calculations.ts) |
 | 2026-07-26 | **[Polish]** | Tooltips read `"1 points"` / `"-1 points"` — no singular form. | [player-gameweek-table.tsx](../draft/app/players/components/player-gameweek-table.tsx) |
+| 2026-07-28 | **[Polish]** | `validateDraftEligibility` has an unreachable branch. The guard at `draft-rules.ts:158` requires `positionCount >= max && subCount >= 1`, which is exactly the condition the branch above it already returned on. Dead while `maxSubstitutes >= 1`. Found by P3.3 while working out which cases were reachable. | [draft-rules.ts](../draft/app/draft/lib/draft-rules.ts) |
 | 2026-07-26 | **[Fixed + tested]** | The defensive-contribution tooltip on the player gameweek table always read **"0 points"** for every player. It passed `stat.defensiveContribution` (a number) where `calculateDefensiveContribution` expects the raw components object, so every field read came back `undefined`, the total was 0, and 0 is below every threshold. Invisible because it was a plausible-looking value. Surfaced only once `TableColumn.title` was declared and the compiler could finally see the call site. Now covered by rendering tests. | [player-gameweek-table.tsx](../draft/app/players/components/player-gameweek-table.tsx) |
 | 2026-07-26 | **[Separate problem found]** | `DraftPickData.teamCode` and `FirebaseDraftPick.teamCode` are typed `string`, but callers assign a number (`FplTeam.code`). Surfaced by P1.3a once the surrounding code stopped being implicit `any`. Causes 3 of the 12 remaining `draft` errors, including a `number === string` comparison in [draft.tsx:202](../draft/app/draft/draft.tsx) that can never be true. Fix during the `draft` burn-down. | [draft-types.ts](../draft/app/draft/types/draft-types.ts) |
 | 2026-07-26 | **[Will slow down future work]** | `scoring/server/services/division-teams.service` has 6 importers across admin, cup, leagues, teams and transfers. It is a de-facto shared service living in a feature domain — the server-side twin of the `gameweek-selector` problem. Decide its home during P2.3. | [division-teams.service.ts](../draft/app/scoring/server/services/division-teams.service.ts) |

--- a/draft/app/draft/lib/calculate-next-picker.test.ts
+++ b/draft/app/draft/lib/calculate-next-picker.test.ts
@@ -1,0 +1,87 @@
+/* Location: app/draft/lib/calculate-next-picker.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { DraftOrderData, DraftStateData } from '../types/draft-types';
+import { calculateNextPicker } from './calculate-next-picker';
+
+const orderOf = (...userNames: string[]): DraftOrderData[] =>
+    userNames.map((userName, index) => ({
+        divisionId: 'premierLeague' as const,
+        position: index + 1,
+        userId: userName.toLowerCase(),
+        userName,
+        generatedAt: new Date('2026-08-01T12:00:00Z'),
+    }));
+
+const ORDER = orderOf('Ann', 'Bob', 'Cat');
+
+/** A live draft, with only the fields a test cares about set per case. */
+const draftState = (overrides: Partial<DraftStateData> = {}): DraftStateData => ({
+    isActive: true,
+    currentUserId: 'ann',
+    divisionId: 'premierLeague',
+    picksPerTeam: 12,
+    startedAt: new Date('2026-08-01T12:00:00Z'),
+    completedAt: null,
+    currentPick: 1,
+    ...overrides,
+});
+
+// This answers "who is ON DECK", not "whose turn is it". The draft room renders it as
+// "Get Ready..." beside the manager after the one currently picking, so it deliberately
+// looks one pick beyond `currentPick`.
+describe('calculateNextPicker', () => {
+    it('names the manager picking after the current one', () => {
+        const next = calculateNextPicker(draftState({ currentPick: 1 }), ORDER);
+
+        expect(next).toEqual({ userId: 'bob', userName: 'Bob', pickNumber: 2 });
+    });
+
+    // At the end of an odd round the snake turns, so the manager on deck is the one
+    // currently picking -- they pick twice in a row. This is the case most likely to be
+    // broken by "simplifying" the reversal.
+    it('names the current picker again at the turn of the round', () => {
+        // Pick 3 is the last of round 1 (Cat). Pick 4 is the first of round 2, also Cat.
+        const next = calculateNextPicker(draftState({ currentPick: 3 }), ORDER);
+
+        expect(next).toEqual({ userId: 'cat', userName: 'Cat', pickNumber: 4 });
+    });
+
+    it('walks back down the order through an even round', () => {
+        // Round 2 runs Cat, Bob, Ann across picks 4, 5, 6.
+        expect(calculateNextPicker(draftState({ currentPick: 4 }), ORDER)?.userName).toBe('Bob'); // pick 5
+        expect(calculateNextPicker(draftState({ currentPick: 5 }), ORDER)?.userName).toBe('Ann'); // pick 6
+    });
+
+    it('turns again at the start of an odd round', () => {
+        // Pick 6 ends round 2 with Ann; pick 7 opens round 3 with Ann.
+        expect(calculateNextPicker(draftState({ currentPick: 6 }), ORDER)?.userName).toBe('Ann');
+    });
+
+    // The draft has to end. Without this the room would keep pointing at someone after
+    // the final pick.
+    it('returns nobody once the final pick has been reached', () => {
+        // 3 managers x 2 picks each = 6 picks; there is no 7th.
+        const atLastPick = draftState({ currentPick: 6, picksPerTeam: 2 });
+
+        expect(calculateNextPicker(atLastPick, ORDER)).toBeNull();
+    });
+
+    it('still names someone on the second-to-last pick', () => {
+        const nearlyDone = draftState({ currentPick: 5, picksPerTeam: 2 });
+
+        expect(calculateNextPicker(nearlyDone, ORDER)?.pickNumber).toBe(6);
+    });
+
+    it('returns nobody when the draft is not active', () => {
+        expect(calculateNextPicker(draftState({ isActive: false }), ORDER)).toBeNull();
+    });
+
+    it('returns nobody when there is no draft state at all', () => {
+        expect(calculateNextPicker(null, ORDER)).toBeNull();
+    });
+
+    it('returns nobody when no draft order has been generated', () => {
+        expect(calculateNextPicker(draftState(), [])).toBeNull();
+    });
+});

--- a/draft/app/draft/lib/draft-pick-calculator.test.ts
+++ b/draft/app/draft/lib/draft-pick-calculator.test.ts
@@ -1,0 +1,112 @@
+/* Location: app/draft/lib/draft-pick-calculator.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { DivisionId } from '../../_shared/types/league-types';
+import type { DraftOrderData, DraftPickData } from '../types/draft-types';
+import { calculateCurrentPick, calculateCurrentUserId } from './draft-pick-calculator';
+import { generateDraftSequence } from './generate-draft-sequence';
+
+const orderOf = (...userNames: string[]): DraftOrderData[] =>
+    userNames.map((userName, index) => ({
+        divisionId: 'premierLeague' as const,
+        position: index + 1,
+        userId: userName.toLowerCase(),
+        userName,
+        generatedAt: new Date('2026-08-01T12:00:00Z'),
+    }));
+
+/** `n` picks already made in a division. Only the count and division matter here. */
+const picksMade = (n: number, divisionId: DivisionId = 'premierLeague'): DraftPickData[] =>
+    Array.from({ length: n }, (_, index) => ({
+        pickNumber: index + 1,
+        round: 1,
+        userId: 'someone',
+        playerId: 100 + index,
+        playerCode: 200 + index,
+        playerName: `Player ${index}`,
+        teamCode: '1',
+        teamName: 'Arsenal',
+        position: 'mid',
+        pickedAt: new Date('2026-08-01T12:00:00Z'),
+        divisionId,
+    }));
+
+const ORDER = orderOf('Ann', 'Bob', 'Cat');
+
+describe('calculateCurrentPick', () => {
+    it('is pick 1 before anyone has drafted', () => {
+        expect(calculateCurrentPick('premierLeague', [])).toBe(1);
+    });
+
+    it('is the pick about to be made, not the last one made', () => {
+        expect(calculateCurrentPick('premierLeague', picksMade(4))).toBe(5);
+    });
+
+    // Each division runs its own independent draft. If picks leaked across divisions,
+    // one division finishing its draft would push another division's draft forward.
+    it('ignores picks made in other divisions', () => {
+        const picks = [...picksMade(2, 'premierLeague'), ...picksMade(7, 'championship')];
+
+        expect(calculateCurrentPick('premierLeague', picks)).toBe(3);
+        expect(calculateCurrentPick('championship', picks)).toBe(8);
+        expect(calculateCurrentPick('leagueOne', picks)).toBe(1);
+    });
+});
+
+describe('calculateCurrentUserId', () => {
+    it('starts with the manager at position 1', () => {
+        expect(calculateCurrentUserId('premierLeague', [], ORDER, 12)).toBe('ann');
+    });
+
+    it('follows the order through the first round', () => {
+        expect(calculateCurrentUserId('premierLeague', picksMade(1), ORDER, 12)).toBe('bob');
+        expect(calculateCurrentUserId('premierLeague', picksMade(2), ORDER, 12)).toBe('cat');
+    });
+
+    // The turn: whoever picked last in round 1 picks first in round 2.
+    it('reverses at the start of an even round', () => {
+        expect(calculateCurrentUserId('premierLeague', picksMade(3), ORDER, 12)).toBe('cat');
+        expect(calculateCurrentUserId('premierLeague', picksMade(4), ORDER, 12)).toBe('bob');
+        expect(calculateCurrentUserId('premierLeague', picksMade(5), ORDER, 12)).toBe('ann');
+    });
+
+    it('reverses back at the start of an odd round', () => {
+        expect(calculateCurrentUserId('premierLeague', picksMade(6), ORDER, 12)).toBe('ann');
+    });
+
+    it('is scoped to its own division', () => {
+        const picks = [...picksMade(1, 'premierLeague'), ...picksMade(5, 'championship')];
+
+        // One pick made in the premier league, so it is the second manager's turn there.
+        expect(calculateCurrentUserId('premierLeague', picks, ORDER, 12)).toBe('bob');
+    });
+
+    // An empty string is the "nobody" signal the draft room checks for.
+    it('names nobody once every pick has been made', () => {
+        expect(calculateCurrentUserId('premierLeague', picksMade(6), ORDER, 2)).toBe('');
+    });
+
+    it('still names someone on the very last pick', () => {
+        expect(calculateCurrentUserId('premierLeague', picksMade(5), ORDER, 2)).toBe('ann');
+    });
+});
+
+// The snake rule is implemented three times: in generateDraftSequence (what the draft
+// room displays), in calculateCurrentUserId (what the server records against a pick),
+// and in calculateNextPicker (the "on deck" badge). If they ever disagree, the room
+// shows one manager's turn while the server accepts a pick from another.
+describe('the displayed order and the recorded order agree', () => {
+    it.each([
+        ['3 managers', orderOf('Ann', 'Bob', 'Cat'), 4],
+        ['5 managers', orderOf('Ann', 'Bob', 'Cat', 'Dee', 'Eve'), 3],
+        ['2 managers', orderOf('Ann', 'Bob'), 6],
+    ])('for %s', (_label, order, picksPerTeam) => {
+        const sequence = generateDraftSequence(order, picksPerTeam);
+
+        const recorded = sequence.map((_entry, index) =>
+            calculateCurrentUserId('premierLeague', picksMade(index), order, picksPerTeam),
+        );
+
+        expect(recorded).toEqual(sequence.map((entry) => entry.userId));
+    });
+});

--- a/draft/app/draft/lib/draft-rules.test.ts
+++ b/draft/app/draft/lib/draft-rules.test.ts
@@ -1,0 +1,174 @@
+/* Location: app/draft/lib/draft-rules.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { CustomPosition } from '../../_shared/types/league-types';
+import { DRAFT_RULES, getSquadComposition, validateDraftEligibility } from './draft-rules';
+
+// A squad is 11 starters (1 gk, 2 each of cb/fb/mid/wa/ca) plus 1 substitute = 12.
+// A manager may hold at most 2 players from any one real-world club.
+
+/** One player a manager has already drafted. */
+const drafted = (position: CustomPosition, teamName = 'Arsenal') => ({
+    position,
+    teamCode: teamName,
+    teamName,
+});
+
+/** A player being considered. Target players carry their position under `draft`. */
+const candidate = (position: CustomPosition, teamName = 'Arsenal') => ({
+    draft: { position },
+    team_code: teamName,
+});
+
+const squadOf = (...picks: ReturnType<typeof drafted>[]) => getSquadComposition(picks);
+
+describe('getSquadComposition', () => {
+    it('counts nothing for a manager who has not drafted', () => {
+        const { positionCounts, teamCounts } = squadOf();
+
+        expect(positionCounts.total).toBe(0);
+        expect(positionCounts.sub).toBe(0);
+        expect(teamCounts).toEqual({});
+    });
+
+    it('counts players into their own position', () => {
+        const { positionCounts } = squadOf(drafted('gk'), drafted('cb'), drafted('cb'), drafted('mid'));
+
+        expect(positionCounts.gk).toBe(1);
+        expect(positionCounts.cb).toBe(2);
+        expect(positionCounts.mid).toBe(1);
+        expect(positionCounts.total).toBe(4);
+    });
+
+    // Overflow is the whole reason `sub` exists: a third midfielder is not a third
+    // midfield slot, it is the squad's one substitute.
+    it('puts a player beyond their position’s maximum into the substitute slot', () => {
+        const { positionCounts } = squadOf(drafted('mid'), drafted('mid'), drafted('mid'));
+
+        expect(positionCounts.mid).toBe(2); // the maximum
+        expect(positionCounts.sub).toBe(1); // the third one
+        expect(positionCounts.total).toBe(3);
+    });
+
+    // Goalkeeper is the only position with a maximum of 1, so it overflows soonest.
+    it('overflows a second goalkeeper to the substitute slot', () => {
+        const { positionCounts } = squadOf(drafted('gk'), drafted('gk'));
+
+        expect(positionCounts.gk).toBe(1);
+        expect(positionCounts.sub).toBe(1);
+    });
+
+    it('counts how many players come from each real-world club', () => {
+        const { teamCounts } = squadOf(drafted('cb', 'Arsenal'), drafted('mid', 'Arsenal'), drafted('wa', 'Chelsea'));
+
+        expect(teamCounts.Arsenal.count).toBe(2);
+        expect(teamCounts.Chelsea.count).toBe(1);
+    });
+});
+
+describe('validateDraftEligibility', () => {
+    it('rejects when no player has been selected', () => {
+        const result = validateDraftEligibility(squadOf(), null);
+
+        expect(result.isEligible).toBe(false);
+        expect(result.violations).toContain('No player selected');
+    });
+
+    it('accepts a player into an empty squad', () => {
+        const result = validateDraftEligibility(squadOf(), candidate('mid'));
+
+        expect(result.isEligible).toBe(true);
+        expect(result.canAddToSub).toBe(false); // goes into a real position, not the bench
+        expect(result.violations).toEqual([]);
+    });
+
+    // The club limit is a hard block: it cannot be worked around by using the bench.
+    it('rejects a third player from the same club', () => {
+        const squad = squadOf(drafted('cb', 'Arsenal'), drafted('mid', 'Arsenal'));
+
+        const result = validateDraftEligibility(squad, candidate('wa', 'Arsenal'));
+
+        expect(result.isEligible).toBe(false);
+        expect(result.canAddToSub).toBe(false);
+        expect(result.violations).toEqual(['Already have 2 players from Arsenal']);
+    });
+
+    it('accepts a second player from the same club', () => {
+        const squad = squadOf(drafted('cb', 'Arsenal'));
+
+        expect(validateDraftEligibility(squad, candidate('mid', 'Arsenal')).isEligible).toBe(true);
+    });
+
+    it('counts club players separately per club', () => {
+        const squad = squadOf(drafted('cb', 'Arsenal'), drafted('mid', 'Arsenal'));
+
+        expect(validateDraftEligibility(squad, candidate('wa', 'Chelsea')).isEligible).toBe(true);
+    });
+
+    // A full position does not end the matter -- the player can still be the sub.
+    it('offers the bench when a position is already full', () => {
+        const squad = squadOf(drafted('mid', 'Arsenal'), drafted('mid', 'Chelsea'));
+
+        const result = validateDraftEligibility(squad, candidate('mid', 'Everton'));
+
+        expect(result.isEligible).toBe(true);
+        expect(result.canAddToSub).toBe(true);
+        expect(result.violations).toContain('Already have 2 Midfielders');
+    });
+
+    // ...but there is only one bench slot, so the next one has nowhere to go.
+    it('rejects a player when their position is full and the bench is taken', () => {
+        const squad = squadOf(
+            drafted('mid', 'Arsenal'),
+            drafted('mid', 'Chelsea'),
+            drafted('mid', 'Everton'), // this one became the substitute
+        );
+
+        const result = validateDraftEligibility(squad, candidate('mid', 'Fulham'));
+
+        expect(result.isEligible).toBe(false);
+        expect(result.canAddToSub).toBe(false);
+    });
+
+    // The bench is shared across the whole squad, not one slot per position.
+    it('rejects a full position when the bench was filled by a different position', () => {
+        const squad = squadOf(
+            drafted('gk', 'Arsenal'),
+            drafted('gk', 'Chelsea'), // second keeper takes the one bench slot
+            drafted('wa', 'Everton'),
+            drafted('wa', 'Fulham'),
+        );
+
+        const result = validateDraftEligibility(squad, candidate('wa', 'Leeds'));
+
+        expect(result.isEligible).toBe(false);
+    });
+
+    it('rejects a player whose position we do not recognise', () => {
+        const result = validateDraftEligibility(squadOf(), candidate('striker' as CustomPosition));
+
+        expect(result.isEligible).toBe(false);
+        expect(result.violations).toEqual(['Unknown position: striker']);
+    });
+
+    // Squad size is checked before anything else, so a full squad reports being full
+    // rather than complaining about a position.
+    it('rejects everyone once the squad is full', () => {
+        const fullSquad = {
+            positionCounts: { gk: 1, cb: 2, fb: 2, mid: 2, wa: 2, ca: 2, sub: 1, total: DRAFT_RULES.totalSquadSize },
+            teamCounts: {},
+        };
+
+        const result = validateDraftEligibility(fullSquad, candidate('mid', 'Leeds'));
+
+        expect(result.isEligible).toBe(false);
+        expect(result.violations).toEqual(['Squad is full (12 players)']);
+    });
+
+    // The rules table and the squad size have to stay consistent: 11 starters + 1 sub.
+    it('has position maximums that add up to the squad size', () => {
+        const starters = Object.values(DRAFT_RULES.positions).reduce((sum, rule) => sum + rule.max, 0);
+
+        expect(starters + DRAFT_RULES.maxSubstitutes).toBe(DRAFT_RULES.totalSquadSize);
+    });
+});

--- a/draft/app/draft/lib/generate-draft-sequence.test.ts
+++ b/draft/app/draft/lib/generate-draft-sequence.test.ts
@@ -1,0 +1,100 @@
+/* Location: app/draft/lib/generate-draft-sequence.test.ts */
+
+import { describe, expect, it } from 'vitest';
+import type { DraftOrderData } from '../types/draft-types';
+import { generateDraftSequence } from './generate-draft-sequence';
+
+// A draft order is one row per manager, and `position` is what the snake reverses.
+// Names are deliberately positional so an expected sequence reads as an order.
+const orderOf = (...userNames: string[]): DraftOrderData[] =>
+    userNames.map((userName, index) => ({
+        divisionId: 'premierLeague' as const,
+        position: index + 1,
+        userId: userName.toLowerCase(),
+        userName,
+        generatedAt: new Date('2026-08-01T12:00:00Z'),
+    }));
+
+/** The thing a manager actually looks at: who picks, in order. */
+const pickingOrder = (sequence: ReturnType<typeof generateDraftSequence>) => sequence.map((entry) => entry.userName);
+
+describe('generateDraftSequence', () => {
+    // The defining property of a snake draft: round 2 runs backwards, round 3 forwards
+    // again. Getting this wrong hands someone two picks in a row that they have not
+    // earned, which is the single most consequential bug this domain can have.
+    it('reverses the order on even rounds and restores it on odd ones', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob', 'Cat'), 4);
+
+        expect(pickingOrder(sequence)).toEqual([
+            'Ann',
+            'Bob',
+            'Cat', // round 1 — forward
+            'Cat',
+            'Bob',
+            'Ann', // round 2 — reversed
+            'Ann',
+            'Bob',
+            'Cat', // round 3 — forward again
+            'Cat',
+            'Bob',
+            'Ann', // round 4 — reversed
+        ]);
+    });
+
+    // The turn of the round is where the snake pays out: whoever picks last in round 1
+    // picks first in round 2, so they get two picks back to back. That is the
+    // compensation for picking last, and it must actually happen.
+    it('gives the last picker of an odd round the first pick of the next', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob', 'Cat'), 2);
+
+        expect(sequence[2].userName).toBe('Cat'); // last pick of round 1
+        expect(sequence[3].userName).toBe('Cat'); // first pick of round 2
+    });
+
+    it('numbers picks continuously across rounds, starting at 1', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob', 'Cat'), 3);
+
+        expect(sequence.map((entry) => entry.pickNumber)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    it('labels each pick with the round it belongs to', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob'), 3);
+
+        expect(sequence.map((entry) => entry.round)).toEqual([1, 1, 2, 2, 3, 3]);
+    });
+
+    it('produces one pick per manager per round', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob', 'Cat', 'Dee'), 12);
+
+        expect(sequence).toHaveLength(48); // 4 managers x 12 rounds
+    });
+
+    // Every manager must get the same number of picks. A snake that drops or repeats
+    // someone would still produce a plausible-looking sequence of the right length.
+    it('gives every manager the same number of picks', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob', 'Cat', 'Dee', 'Eve'), 6);
+
+        const picksEach = sequence.reduce<Record<string, number>>((acc, entry) => {
+            acc[entry.userName] = (acc[entry.userName] || 0) + 1;
+            return acc;
+        }, {});
+
+        expect(picksEach).toEqual({ Ann: 6, Bob: 6, Cat: 6, Dee: 6, Eve: 6 });
+    });
+
+    // A two-manager draft is the smallest case where reversal is observable, and the
+    // one most likely to be special-cased by accident.
+    it('still snakes with only two managers', () => {
+        const sequence = generateDraftSequence(orderOf('Ann', 'Bob'), 4);
+
+        expect(pickingOrder(sequence)).toEqual(['Ann', 'Bob', 'Bob', 'Ann', 'Ann', 'Bob', 'Bob', 'Ann']);
+    });
+
+    it('returns nothing for an empty draft order', () => {
+        expect(generateDraftSequence([], 12)).toEqual([]);
+    });
+
+    it('returns nothing when there are no rounds to play', () => {
+        expect(generateDraftSequence(orderOf('Ann', 'Bob'), 0)).toEqual([]);
+    });
+});


### PR DESCRIPTION
draft/lib/ held the rule that decides whose turn it is and had zero tests. P2.7 is about to restructure this domain, and the working agreement is that the tests protecting a refactor come before it.

47 tests across four files; suite 249 -> 296.

- generate-draft-sequence: the even-round reversal, the double pick at the turn of a round, continuous numbering, equal picks per manager, and the two-manager case where reversal is easiest to special-case by accident.
- calculate-next-picker: who is on deck, end of draft, inactive/absent state.
- draft-pick-calculator: division scoping, and the empty-string "nobody".
- draft-rules: position maximums, bench overflow, the 2-per-club hard block, unknown positions, full squad.

The snake rule is implemented THREE times -- generateDraftSequence (what the draft room shows), calculateCurrentUserId (what the server records against a pick) and calculateNextPicker (the "on deck" badge). If they drift, the room shows one manager's turn while the server accepts a pick from another. There is now a test asserting the first two produce identical picking orders across 2-, 3- and 5-manager drafts.

calculateNextPicker reads currentPick + 1, which looks like an off-by-one. It is not: the draft room renders it as "Get Ready..." with an onDeck class, so it means the manager AFTER the one currently picking. Verified against the component before writing the test rather than encoding the surprise as fact.

Not covered: "the same player cannot be picked twice in a division". That guard lives in draft.server.ts, not lib/, and needs the injection seam P3.4 is waiting on. Carried into P3.4 in the backlog.

Also logs one finding: validateDraftEligibility has an unreachable branch (draft-rules.ts:158 requires exactly the condition the branch above already returned on). Left alone, recorded in the backlog.