### PR TITLE
Test the draft domain, then give it a public API (P3.3 + P2.7)

### DIFF
--- a/.kiro/backlog.md
+++ b/.kiro/backlog.md
@@ -28,11 +28,11 @@ git log --oneline -15
 
 | | Why |
 |---|---|
-| **P2.7 — public API for `draft`** | Unblocks moving `firebase-draft-sync.ts` into the domain and removes the allowlist entry P2.3 had to add. Makes Rule 2 real rather than aspirational. **`draft/lib/` is now covered by P3.3**, so the restructure has tests holding it in place — do it in that order. |
+| **P2.7 — public API for `scoring`** | `draft` is done and is the worked example to copy. `division-teams.service` has 6 importers across 5 domains — the worst offender, and it stands between P2.3 and its remaining readers. |
 | **P2.3 — remaining sheets readers** | `transfers.ts`, `cup.ts`, `player-gw-points.ts`. `draft.ts` is done and is the worked example to copy. |
 | **P3.4 — first loader test** | Blocked on P2.3 giving it an injection seam. Also inherits the duplicate-pick rule P3.3 could not reach. |
 
-*Recently done: P4.5 (steering doc back in line with reality, plus a drift check), P3.3 (draft/lib now has 47 tests).*
+*Recently done: P4.5 (steering doc realigned + drift check), P3.3 (draft/lib now has 47 tests), P2.7 for `draft` (first domain with a public API).*
 
 **Working agreements that are not obvious from the code:**
 - Consumer-focused tests that survive refactoring come **before** the refactor they protect. We violated this early and it cost us.
@@ -91,6 +91,7 @@ Newest domain, 12 test files, zero type errors. When in doubt about how somethin
 | 2026-07-26 | One shared **ratchet** mechanism for both type errors and CSS | Same mental model for both backlogs, one script, one baseline file (`.ratchet.json`) |
 | 2026-07-26 | **Each domain gets a public API (`index.ts`); `server/` and `components/` become private** | Three items stalled because `admin` orchestrates other domains — its actual job — with no legal way to reach their logic, which is why 10 `admin -> X/server` entries sit allowlisted. An index lets a domain expose an operation without exposing everything behind it. Chosen over exempting `admin` from Rule 2, which would have been the same debt without admitting it. |
 | 2026-07-26 | **Sheets access is a cross-cutting concern. Every sheet reader lives in `_shared/lib/sheets/`, with no exceptions** | One spreadsheet, one client, one auth, one cache strategy — it is the app's persistence layer. Splitting a reader out because of who happens to read it today is arbitrary and reverses the moment a second domain needs that data. An exception costs every future contributor the question "where do we read sheets?" |
+| 2026-07-28 | **A domain gets TWO public entry points: `index.ts` (client-safe) and `index.server.ts`** | Found doing P2.7 for `draft`. `FirebaseDraftSync` reaches `firebase.realtime-admin`, which parses a service account from `process.env` **at module scope**. Re-exporting it from `index.ts` would make the entire public API unsafe to import from a component, and the failure mode is `process is not defined` in the browser rather than a build error. A single barrel per domain would have quietly forced every domain's public API to be server-only. Verified both ways with throwaway probes: `index.ts` imports clean with no credentials, `index.server.ts` throws. |
 
 ---
 
@@ -107,9 +108,9 @@ Re-measure with `yarn ratchet` and `yarn test`. Committed counts live in `.ratch
 | CI type check | `continue-on-error: true` — cannot fail a PR | ratcheted, blocking |
 | Root `yarn type-check` | fails: `command not found: tsc` | works |
 | Pre-commit hook | never ran (see P0.6) | runs lint-staged + tests |
-| `_shared` → domain imports | 34, across 6 domains | **10** — P2.1 + P2.4 + P2.3 (draft) |
+| `_shared` → domain imports | 34, across 6 domains | **9** — P2.1 + P2.4 + P2.3 (draft) + P2.7 (draft) |
 | Architecture rules enforced | 0 | **5** (P1.2, P4.5) |
-| Domain dependency cycles | 15 | **13** — P2.4 dissolved two |
+| Domain dependency cycles | 15 | **12** — P2.4 dissolved two, P2.7 (draft) a third |
 
 ### Type errors by domain
 
@@ -371,14 +372,29 @@ The real DDD work. Large, but correct — and it is what unblocks route-loader t
 
   **Order — start where the pain is:**
 
-  | Domain | First job |
-  |---|---|
-  | `draft` | expose draft state + sync so `firebase-draft-sync.ts` can move into the domain and `admin` can still call it |
-  | `scoring` | `division-teams.service` has 6 importers across 5 domains — the single worst offender |
-  | `transfers` | `transfers-data.service`, used by admin |
-  | rest | as their allowlist entries come up |
+  | Domain | First job | |
+  |---|---|---|
+  | `draft` | expose draft state + sync so `firebase-draft-sync.ts` can move into the domain and `admin` can still call it | ✅ **done** |
+  | `scoring` | `division-teams.service` has 6 importers across 5 domains — the single worst offender | next |
+  | `transfers` | `transfers-data.service`, used by admin | |
+  | rest | as their allowlist entries come up | |
 
-  *Acceptance:* each domain has an `index.ts`; `MAY_REACH_INSIDE` is empty; `TRANSITIONAL_PUBLIC_SEGMENTS` is empty, making `index.ts` the only cross-domain entry point.
+  ### ✅ `draft` — done
+
+  `firebase-draft-sync.ts` moved from `_shared/lib/firestore-cache/` to `draft/server/` with `git mv`, so history follows it. Its only draft dependency (`calculateCurrentPick`) became internal, which is what made the move possible at all.
+
+  - **`_shared` → domain imports 10 → 9**, and the allowlist entry P2.3 was forced to add is gone.
+  - **A dependency cycle dissolved, 13 → 12.**
+  - `admin` now calls draft orchestration through the public API instead of reaching into `_shared`.
+
+  **Two things fell out of it, both worth knowing before doing the next domain:**
+
+  **1. The rule did not recognise its own target.** A bare `import … from '../../draft'` resolves to `draft/index.ts`, but the parser recorded a segment-less path and reported it as reaching inside. Nobody had noticed, because no domain had an index yet. Fixed by normalising bare and extensionless index specifiers.
+
+  **2. One barrel per domain would have been wrong.** See the decisions log — `index.ts` is client-safe, `index.server.ts` is for anything touching Firebase, Sheets or `process.env`. Without the split, `draft/index.ts` would have dragged the Firebase admin SDK into every component importing it, failing at runtime in the browser rather than at build time.
+
+  *Acceptance (whole item):* each domain has an `index.ts`; `MAY_REACH_INSIDE` is empty; `TRANSITIONAL_PUBLIC_SEGMENTS` is empty, making the index the only cross-domain entry point.
+  *Note:* `TRANSITIONAL_PUBLIC_SEGMENTS` is global, so it cannot come out until every domain has an index. `draft`'s own `types/` and `lib/` are still imported directly by `admin`, `players`, `transfers` and `scoring` — legal for now, and a tidy-up for when the flag goes.
 
 - [ ] **P2.5 — Promote genuinely shared components**
   `teams/components/gameweek-selector` is used by transfers, leagues, players and admin. `players/components/player` is used by teams, transfers, admin and wishlist. Both belong in `_shared/components/`.

--- a/.kiro/steering/ai-contribution-rules.md
+++ b/.kiro/steering/ai-contribution-rules.md
@@ -79,6 +79,17 @@ import { getDraftStates } from '../draft';
 import { readDraftState } from '../draft/server/draft.server';
 ```
 
+**A domain has two entry points, and the split matters.**
+
+| File | For | Safe to import from a component? |
+|---|---|---|
+| `index.ts` | types, rules, pure logic | ✅ yes |
+| `index.server.ts` | operations touching Firebase, Sheets or `process.env` | ❌ no |
+
+They are separate because several server modules do work **at import time** — `firebase.realtime-admin` parses a service account from `process.env` at module scope. Re-exporting anything that reaches it from `index.ts` would make the whole public API unsafe to import from a component, and the failure would be a `process is not defined` crash in the browser rather than a build error.
+
+So: if it touches Firebase, Google Sheets or `process.env`, it goes in `index.server.ts`. If a component could reasonably import it, it goes in `index.ts`. `draft/` is the worked example.
+
 This exists because **`admin` orchestrates other domains** — that is its job — and previously had no legal way to do it, so it reached into their server code. An index lets a domain say *"this operation is for others to call"* without exposing everything behind it.
 
 **Transitional:** importing another domain's `types/` and `lib/` is still accepted while indexes are introduced (see P2.7 in the backlog). Prefer the index for anything new.

--- a/draft/app/admin/server/services/draft-sync-comparison.service.ts
+++ b/draft/app/admin/server/services/draft-sync-comparison.service.ts
@@ -94,7 +94,7 @@ async function generateAllDraftSyncComparisons(): Promise<DraftSyncComparison[]>
  */
 async function getFirebaseDraftState(divisionId: DivisionId): Promise<FirebaseDraftState | null> {
     try {
-        const { FirebaseDraftSync } = await import('../../../_shared/lib/firestore-cache/firebase-draft-sync');
+        const { FirebaseDraftSync } = await import('../../../draft/index.server');
         return await FirebaseDraftSync.getDraftState(divisionId);
     } catch (error) {
         console.error(`❌ Failed to get Firebase draft state for ${divisionId}:`, error);

--- a/draft/app/admin/server/services/draft.service.ts
+++ b/draft/app/admin/server/services/draft.service.ts
@@ -2,7 +2,6 @@
 
 import { getInvalidationKeys } from '../../../_shared/lib/cache/cache-config';
 import { dataCache } from '../../../_shared/lib/cache/data-cache.service';
-import { FirebaseDraftSync } from '../../../_shared/lib/firestore-cache/firebase-draft-sync';
 import { readDraftStateByDivision, updateDraftState } from '../../../_shared/lib/sheets/draft';
 import {
     clearDraftOrder,
@@ -12,6 +11,7 @@ import {
 } from '../../../_shared/lib/sheets/draft-order';
 import type { DivisionId, UserTeamsSheetData } from '../../../_shared/types/league-types';
 import type { DraftStateRow } from '../../../_shared/types/sheets-types';
+import { FirebaseDraftSync } from '../../../draft/index.server';
 import type { DraftResult } from '../../types/admin-orchestrator-types';
 import type { AdminActionResult } from '../../types/admin-types';
 import { handleCommitTeamsToFirestore } from '../actions/team-commit-actions';

--- a/draft/app/architecture.test.ts
+++ b/draft/app/architecture.test.ts
@@ -37,6 +37,13 @@ type Import = {
     toSegment: string;
 };
 
+/** How an import specifier for a domain's index appears once the extension is dropped. */
+const INDEX_SPECIFIERS: Record<string, string> = {
+    '': 'index.ts', // "../../draft"
+    index: 'index.ts', // "../../draft/index"
+    'index.server': 'index.server.ts', // "../../draft/index.server"
+};
+
 const sourceFiles = readdirSync(appDir, { recursive: true, withFileTypes: true })
     .filter((entry) => entry.isFile() && /\.tsx?$/.test(entry.name))
     .map((entry) => join(entry.parentPath, entry.name));
@@ -54,8 +61,13 @@ const crossDomainImports: Import[] = sourceFiles.flatMap((absolutePath) => {
         const toPath = relative(appDir, resolve(dirname(absolutePath), specifier));
         if (toPath.startsWith('..')) return [];
 
-        const [toDomain, toSegment = ''] = toPath.split(sep);
+        const [toDomain, rawSegment = ''] = toPath.split(sep);
         if (!domains.includes(toDomain) || toDomain === fromDomain) return [];
+
+        // Imports omit the extension, and a bare domain import ("../../draft") resolves
+        // to that domain's index. Normalise both so the public-API rule recognises them
+        // instead of seeing a segment-less reach inside.
+        const toSegment = INDEX_SPECIFIERS[rawSegment] ?? rawSegment;
 
         return [{ from: fromPath, to: toPath, fromDomain, toDomain, toSegment }];
     });
@@ -80,12 +92,6 @@ const report = (violations: Import[], guidance: string) =>
 // the vocabulary of every feature. Phase 2 fixes it by naming a shared kernel (P2.1)
 // and moving each sheets module into the domain that owns it (P2.3, P2.4).
 const SHARED_MAY_IMPORT: ReadonlySet<string> = new Set([
-    // NEW in P2.3. firebase-draft-sync.ts is draft ORCHESTRATION (sync the draft
-    // between Sheets and Firebase) that happens to live in _shared. It needs the
-    // derived currentPick, so taking the derivation out of the sheets reader moved
-    // the dependency here rather than removing it. The real fix is to move that file
-    // into the draft domain -- blocked on the orchestrator question in the backlog.
-    '_shared/lib/firestore-cache/firebase-draft-sync.ts -> draft/lib/draft-pick-calculator',
     '_shared/lib/fpl/api-cache.ts -> scoring/types/scoring-types',
     '_shared/lib/fpl/fpl-firestore.ts -> scoring/lib',
     '_shared/lib/fpl/fpl-firestore.ts -> scoring/types/scoring-types',
@@ -150,7 +156,11 @@ describe('_shared must not depend on a domain', () => {
 // Ten of the entries below are exactly that. An index gives a domain a way to say "this
 // operation is for other domains to call" without exposing everything behind it. See the
 // orchestrator discussion under P2.3 in .kiro/backlog.md.
-const PUBLIC_API_ENTRYPOINTS = ['index.ts', 'index.tsx'];
+// `index.server.ts` is a second, server-only entry point. It exists because a domain's
+// server operations reach modules that touch Firebase/Sheets/process.env at import time,
+// and re-exporting those from index.ts would make the whole public API unsafe to import
+// from a component. See the decisions log in .kiro/backlog.md (2026-07-28).
+const PUBLIC_API_ENTRYPOINTS = ['index.ts', 'index.tsx', 'index.server.ts'];
 const TRANSITIONAL_PUBLIC_SEGMENTS = ['types', 'lib'];
 
 const PUBLIC_SEGMENTS = [...PUBLIC_API_ENTRYPOINTS, ...TRANSITIONAL_PUBLIC_SEGMENTS];
@@ -237,7 +247,7 @@ describe('a domain may only use another domain’s public API', () => {
 // understand, test or move scoring without also holding players, teams and transfers in
 // your head. Most of the current ones dissolve once Rule 1 and Rule 2 are satisfied,
 // so this is measured as a count that may only go down (P2.6).
-const KNOWN_CYCLIC_PAIRS = 13;
+const KNOWN_CYCLIC_PAIRS = 12;
 
 describe('the domain dependency graph', () => {
     const graph = new Map<string, Set<string>>();

--- a/draft/app/draft/index.server.ts
+++ b/draft/app/draft/index.server.ts
@@ -1,0 +1,18 @@
+/* Location: app/draft/index.server.ts */
+
+/**
+ * The draft domain's SERVER-ONLY public API.
+ *
+ * Split from `index.ts` because the modules behind it touch Firebase and `process.env`
+ * at import time — `firebase.realtime-admin` parses a service account at module scope.
+ * Anything re-exporting that is unsafe to import from a component, so the two surfaces
+ * are kept apart rather than relying on tree-shaking to save us.
+ *
+ * Rule of thumb: if it touches Firebase, Google Sheets or `process.env`, it goes here.
+ * If a component could reasonably import it, it goes in `index.ts`.
+ */
+
+// Draft orchestration: keeps the Sheets draft and the Firebase Realtime draft in step.
+// Lived in `_shared/lib/firestore-cache/` because `admin` and `draft` both need it and
+// there was no legal way to share it from the domain until this file existed.
+export { FirebaseDraftSync } from './server/firebase-draft-sync';

--- a/draft/app/draft/index.ts
+++ b/draft/app/draft/index.ts
@@ -1,0 +1,60 @@
+/* Location: app/draft/index.ts */
+
+/**
+ * The draft domain's public API.
+ *
+ * This is the only file other domains may import from. `components/`, `server/` and the
+ * internal helpers behind these exports are private — see
+ * `.kiro/steering/ai-contribution-rules.md`, "A domain is reached only through its
+ * public API", enforced by `architecture.test.ts`.
+ *
+ * `admin` is the main consumer: orchestrating the draft is its job, and before this file
+ * existed it had no legal way to do it, so it reached into `_shared` and `draft/server`
+ * instead. Add an export here when another domain genuinely needs an operation — not to
+ * make an import compile.
+ */
+
+// --- The snake ---------------------------------------------------------------
+export { calculateCurrentPick, calculateCurrentUserId } from './lib/draft-pick-calculator';
+// --- Draft rules -------------------------------------------------------------
+// Squad shape and eligibility. `players`, `transfers` and `scoring` all ask these
+// questions about a squad, so they are part of the contract rather than internal.
+export { DRAFT_RULES, getPlayerPosition, getSquadComposition, validateDraftEligibility } from './lib/draft-rules';
+// --- Draft state -------------------------------------------------------------
+// `currentPick` is derived from the picks a division has made, not stored. These turn
+// raw sheet rows into that derived state; the sheets readers deliberately do not.
+export { toDraftStateForDivision, toDraftStates } from './lib/draft-state';
+export { generateDraftSequence } from './lib/generate-draft-sequence';
+// --- Types -------------------------------------------------------------------
+// The draft concepts other domains model against. Owned here; imported everywhere.
+export type {
+    DraftActionData,
+    DraftDivisionStatus,
+    DraftLoaderData,
+    DraftOrderData,
+    DraftPickData,
+    DraftSequence,
+    DraftSequenceEntry,
+    DraftStage,
+    DraftStateData,
+    DraftStatusByDivisionId,
+    DraftStatusData,
+    DraftSyncComparison,
+    DraftSyncDifference,
+    FirebaseDraftPick,
+    FirebaseDraftState,
+    PositionCounts,
+    SquadComposition,
+    TeamCounts,
+} from './types/draft-types';
+
+// --- Server-only operations are NOT here -------------------------------------
+// `FirebaseDraftSync` lives in `./index.server`, deliberately.
+//
+// It reaches `_shared/lib/firestore-cache/firebase.realtime-admin`, which parses a
+// service account from `process.env` at MODULE SCOPE. Re-exporting it here would make
+// this file server-only, and any client component importing `../../draft` would pull in
+// firebase-admin and blow up on `process`.
+//
+// Keep this file safe to import from a component. Anything touching Firebase, Sheets or
+// `process.env` belongs in `index.server.ts`.

--- a/draft/app/draft/server/draft.server.ts
+++ b/draft/app/draft/server/draft.server.ts
@@ -3,7 +3,6 @@
 
 import { getInvalidationKeys } from '../../_shared/lib/cache/cache-config';
 import { dataCache } from '../../_shared/lib/cache/data-cache.service';
-import { FirebaseDraftSync } from '../../_shared/lib/firestore-cache/firebase-draft-sync';
 import { fplApiCache } from '../../_shared/lib/fpl/api-cache';
 import { readDivisions } from '../../_shared/lib/sheets/divisions';
 import {
@@ -20,6 +19,7 @@ import { calculateCurrentPick, calculateCurrentUserId } from '../lib/draft-pick-
 import { toDraftStateForDivision, toDraftStates } from '../lib/draft-state';
 import { generateDraftSequence } from '../lib/generate-draft-sequence';
 import type { DraftLoaderData, DraftOrderData, DraftPickData } from '../types/draft-types';
+import { FirebaseDraftSync } from './firebase-draft-sync';
 
 export async function loadDraftData(url: URL): Promise<DraftLoaderData> {
     const selectedUser = url.searchParams.get('user') || '';

--- a/draft/app/draft/server/firebase-draft-sync.ts
+++ b/draft/app/draft/server/firebase-draft-sync.ts
@@ -1,9 +1,9 @@
-/* Location: app/_shared/lib/firestore-cache/firebase-draft-sync.ts */
+/* Location: app/draft/server/firebase-draft-sync.ts */
 // biome-ignore-all lint/complexity/noStaticOnlyClass: class pattern used for Firebase service grouping
 
-// /_shared/lib/firestore-cache/firebase-draft-sync.ts - ENHANCED WITH RESET CAPABILITY
-import type { DivisionId } from '../../types/league-types';
-import { getRealtimeAdminDbInstance } from './firebase.realtime-admin';
+import { getRealtimeAdminDbInstance } from '../../_shared/lib/firestore-cache/firebase.realtime-admin';
+// draft/server/firebase-draft-sync.ts - ENHANCED WITH RESET CAPABILITY
+import type { DivisionId } from '../../_shared/types/league-types';
 
 interface DraftEvent {
     type: 'pick-made' | 'turn-change' | 'draft-started' | 'draft-ended' | 'draft-synced' | 'draft-reset';
@@ -324,9 +324,9 @@ export class FirebaseDraftSync {
 
         try {
             // Import sheets functions dynamically
-            const { readDraftStateByDivision } = await import('../../lib/sheets/draft');
-            const { getDraftPicksByDivision } = await import('../../lib/sheets/draft');
-            const { getDraftOrderByDivision } = await import('../../lib/sheets/draft-order');
+            const { readDraftStateByDivision } = await import('../../_shared/lib/sheets/draft');
+            const { getDraftPicksByDivision } = await import('../../_shared/lib/sheets/draft');
+            const { getDraftOrderByDivision } = await import('../../_shared/lib/sheets/draft-order');
 
             // Get data from sheets (source of truth)
             const [draftState, draftPicks, draftOrder] = await Promise.all([
@@ -345,7 +345,7 @@ export class FirebaseDraftSync {
 
             // currentPick is derived, not stored: the sheets reader returns rows only,
             // so it is computed here from the picks this division has already made.
-            const { calculateCurrentPick } = await import('../../../draft/lib/draft-pick-calculator');
+            const { calculateCurrentPick } = await import('../lib/draft-pick-calculator');
             const currentPick = calculateCurrentPick(divisionId, draftPicks);
             const currentUserId = draftState.currentUserId;
             const isActive = draftState.isActive;


### PR DESCRIPTION
Backlog items **P3.3** and **P2.7 (`draft`)**. Two commits, in that order deliberately: the tests come before the refactor they protect, per the working agreement in `.kiro/backlog.md`.

## 1. `ebdaecf` — test the draft domain

`draft/lib/` held the rule that decides whose turn it is and had **zero tests**. 47 tests added across four files; suite **249 → 296**.

| File | Covers |
|---|---|
| `generate-draft-sequence` | the even-round reversal, the double pick at the turn of a round, continuous numbering, equal picks per manager, two-manager and empty cases |
| `calculate-next-picker` | who is "on deck", end of draft, inactive/absent state |
| `draft-pick-calculator` | division scoping, the snake as the server records it, the empty-string "nobody" signal |
| `draft-rules` | position maximums, bench overflow, the 2-per-club hard block, unknown positions, full squad |

**The snake rule is implemented three times** — `generateDraftSequence` (what the draft room shows), `calculateCurrentUserId` (what the server records against a pick) and `calculateNextPicker` (the "on deck" badge). If they drift, the room shows one manager's turn while the server accepts a pick from another, live, with no error. There is now a test asserting the first two produce identical picking orders across 2-, 3- and 5-manager drafts.

**`calculateNextPicker` reads `currentPick + 1`, which looks like an off-by-one.** It is not — the draft room renders it as "Get Ready…" with an `onDeck` class, i.e. the manager *after* the one currently picking. Verified against the component before writing the test, rather than encoding the surprise as fact. The test names it "on deck" so nobody "fixes" it later.

## 2. `91b3d5c` — give `draft` a public API

The first domain to get one. `admin` orchestrates other domains — that is its job — and had no legal way to do it, so it reached into `_shared` and `draft/server`. Three backlog items had stalled on this.

- `git mv _shared/lib/firestore-cache/firebase-draft-sync.ts` → `draft/server/`, so history follows it. Its only draft dependency (`calculateCurrentPick`) became **internal**, which is what made the move legal at all — that dependency was the allowlist entry P2.3 was forced to add.
- `draft/index.ts` — types, `DRAFT_RULES`, squad/eligibility, draft state, the snake.
- `draft/index.server.ts` — `FirebaseDraftSync`.
- `admin` now calls draft orchestration through the public API.

**`_shared` → domain imports 10 → 9. One dependency cycle dissolved, 13 → 12.**

## Two things a reviewer should know

**Two entry points, not one — and this changes the plan for every remaining domain.**

`firebase.realtime-admin.ts` parses a service account from `process.env` **at module scope**. Re-exporting `FirebaseDraftSync` from `index.ts` would have made the whole public API server-only, so any component doing `import { DRAFT_RULES } from '../../draft'` would crash with `process is not defined` **in the browser at runtime**, not at build time. A single barrel per domain would have quietly forced every domain's public API to be server-only.

Verified both directions with throwaway probes — `index.ts` imports clean with no credentials, `index.server.ts` throws — then deleted them. Recorded in the backlog decisions log and in `ai-contribution-rules.md`.

**`architecture.test.ts` did not recognise its own target.** It reported `admin -> draft` as *reaching inside*: a bare `from '../../draft'` resolves to `draft/index.ts`, but the parser saw a segment-less path and had no case for it. Nobody had noticed because no domain had an index yet — the rule had never been exercised against the thing it was steering toward. Fixed by normalising bare and extensionless index specifiers.

## Verification

- **296 tests pass** (from 249), 32 files.
- `yarn ratchet` unchanged: 177 type errors, 175 CSS, 266 lint. `KNOWN_CYCLIC_PAIRS` lowered 13 → 12, which the ratchet *requires* — it fails if a count goes down without being locked in.

## Not done, deliberately

- **"The same player cannot be picked twice in a division"** is named in the testing conventions but is not covered here. That guard is in `draft.server.ts:150`, not `lib/`, and needs the injection seam **P3.4** is blocked on. Carried into P3.4 rather than dropped. The division-*scoping* half is covered.
- **`TRANSITIONAL_PUBLIC_SEGMENTS` is global**, so it cannot be removed until every domain has an index. `draft`'s own `types/` and `lib/` are still imported directly by `admin`, `players`, `transfers` and `scoring` — legal today, tidy-up later. `draft` is index-only for its *server* surface, not yet for everything.
- One **[Polish]** finding logged, not fixed: `validateDraftEligibility` has an unreachable branch (`draft-rules.ts:158` requires exactly the condition the branch above already returned on).

## Splitting

The two commits are independent and could be split into separate PRs if preferred — P3.3 touches only test files. They are together because P2.7 restructures the code P3.3 covers, and reviewing them as a pair shows the tests holding still across the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
