### PR TITLE
Make MSW the standard for anything crossing the network

### DIFF
--- a/.kiro/backlog.md
+++ b/.kiro/backlog.md
@@ -30,7 +30,7 @@ git log --oneline -15
 |---|---|
 | **P2.7 — public API for `scoring`** | `draft` is done and is the worked example to copy. `division-teams.service` has 6 importers across 5 domains — the worst offender, and it stands between P2.3 and its remaining readers. |
 | **P2.3 — remaining sheets readers** | `transfers.ts`, `cup.ts`, `player-gw-points.ts`. `draft.ts` is done and is the worked example to copy. |
-| **P3.4 — first loader test** | Blocked on P2.3 giving it an injection seam. Also inherits the duplicate-pick rule P3.3 could not reach. |
+| **P3.4 — first loader test** | **No longer blocked** — MSW substitutes at the network boundary, so it needs no injection seam. Costs one fixture-service-account helper, then every loader test reuses it. |
 
 *Recently done: P4.5 (steering doc realigned + drift check), P3.3 (draft/lib now has 47 tests), P2.7 for `draft` (first domain with a public API).*
 
@@ -91,6 +91,7 @@ Newest domain, 12 test files, zero type errors. When in doubt about how somethin
 | 2026-07-26 | One shared **ratchet** mechanism for both type errors and CSS | Same mental model for both backlogs, one script, one baseline file (`.ratchet.json`) |
 | 2026-07-26 | **Each domain gets a public API (`index.ts`); `server/` and `components/` become private** | Three items stalled because `admin` orchestrates other domains — its actual job — with no legal way to reach their logic, which is why 10 `admin -> X/server` entries sit allowlisted. An index lets a domain expose an operation without exposing everything behind it. Chosen over exempting `admin` from Rule 2, which would have been the same debt without admitting it. |
 | 2026-07-26 | **Sheets access is a cross-cutting concern. Every sheet reader lives in `_shared/lib/sheets/`, with no exceptions** | One spreadsheet, one client, one auth, one cache strategy — it is the app's persistence layer. Splitting a reader out because of who happens to read it today is arbitrary and reverses the moment a second domain needs that data. An exception costs every future contributor the question "where do we read sheets?" |
+| 2026-07-28 | **MSW is the standard for anything crossing the network; it is not a "mock"** | `testing-conventions.md` banned mocks and named injecting a fake Sheets client as the alternative, which read as ruling MSW out. That conflated two different things. Replacing a *module* is a fiction about how the code is assembled and goes stale on any refactor. Replacing a *network response* is not — the network is a boundary the app genuinely crosses. MSW intercepts there, so the real FPL client, the real `googleapis` client, its auth and its parsing all still run. That is **more** real coverage than a fake client, which only proves the interpretation code works when handed a perfect object. Rule reworded to "no module mocks — substitute at a real boundary". |
 | 2026-07-28 | **A domain gets TWO public entry points: `index.ts` (client-safe) and `index.server.ts`** | Found doing P2.7 for `draft`. `FirebaseDraftSync` reaches `firebase.realtime-admin`, which parses a service account from `process.env` **at module scope**. Re-exporting it from `index.ts` would make the entire public API unsafe to import from a component, and the failure mode is `process is not defined` in the browser rather than a build error. A single barrel per domain would have quietly forced every domain's public API to be server-only. Verified both ways with throwaway probes: `index.ts` imports clean with no credentials, `index.server.ts` throws. |
 
 ---
@@ -293,7 +294,9 @@ The real DDD work. Large, but correct — and it is what unblocks route-loader t
   **The settled rule:**
   > Every sheets reader lives in `_shared/lib/sheets/`. None of them import a domain. They return **raw row types** declared in `_shared/types/sheets-types.ts`; each domain interprets its own rows into its own model.
 
-  That is one rule with no exceptions, and it fixes all 12 remaining violations by the same mechanism. It is also what creates the injection seam P3.4 needs — a reader that only returns rows is trivial to fake.
+  That is one rule with no exceptions, and it fixes all 12 remaining violations by the same mechanism.
+
+  *Rationale corrected 2026-07-28:* this item used to claim it was **what unblocks P3.4**, on the basis that a row-returning reader is trivial to fake. That is no longer the argument — MSW substitutes at the network boundary, so P3.4 does not need the seam. P2.3 still stands on its own terms (Rule 1: `_shared` must not import a domain), but it is no longer a prerequisite for loader tests, and the two can be done in either order.
 
   **P2.1 already did three of them for free.** `divisions.ts`, `user-teams.ts` and `players.ts` have zero domain imports because their types moved to the kernel. They are the model for the rest.
 
@@ -448,8 +451,17 @@ Ordered by risk. The existing tests are good — this is a coverage-placement pr
   *Not covered:* "the same player cannot be picked twice in a division". That guard is in `draft.server.ts:150`, not `lib/`, and needs the injection seam P3.4 is waiting on. Carried into P3.4.
 
 - [ ] **P3.4 — First route-loader test**
-  Named as the priority boundary in the testing conventions, currently impossible because sheets modules are imported directly with no injection seam. **Blocked on P2.3.**
-  *Also carries from P3.3:* the "same player cannot be picked twice in a division" rule, which lives in `draft.server.ts:150` and needs the same seam.
+  Named as the priority boundary in the testing conventions, and there is still not one test there.
+
+  **No longer hard-blocked on P2.3.** That block assumed the only way in was an injection seam. With MSW the substitution happens at the network boundary instead, so the sheets modules can be imported exactly as they are — and the real `googleapis` client, its auth and its parsing all run for real, which is better coverage than a fake client would give.
+
+  *One-off setup cost, not a blocker:* `_shared/lib/sheets/utils/common.ts` uses `google.auth.JWT`, which signs a JWT **locally** with `credentials.private_key` before exchanging it at `oauth2.googleapis.com/token`. So a test needs a fixture service account (throwaway RSA key — the signature is never verified by anything in the test) plus MSW handlers for the token endpoint and `sheets.googleapis.com`. Write that helper once and every loader test reuses it.
+
+  *Watch out:* `common.ts` memoises the client in a module-scope `sheetsClientPromise`, so it survives between tests in a file — the same singleton problem already logged against `DataCacheService`.
+
+  *Also carries from P3.3:* the "same player cannot be picked twice in a division" rule, which lives in `draft.server.ts:150`.
+
+  *Acceptance:* one loader test exists and the pattern is documented in the testing conventions.
   Establish the pattern once — inject a fake sheets client returning fixtures, assert the loader's returned shape for a given URL and division — then replicate across loaders.
   *Acceptance:* one loader test exists and the pattern is documented in the testing conventions.
 

--- a/.kiro/steering/testing-conventions.md
+++ b/.kiro/steering/testing-conventions.md
@@ -29,14 +29,47 @@ Tests must never be written to make a known bug pass. A test that asserts broken
 
 Test what the feature does, not how it does it. For a server loader, test what data it returns for a given input. For a scoring function, test what points it produces for a given stat line. For a transfer validation, test which transfers are accepted and rejected.
 
-### No mocks — use real implementations
+### No module mocks — substitute at a real boundary
 
-Do not mock modules, functions, or data layers in tests unless it is physically impossible to avoid (e.g. a third-party HTTP call). Instead:
+Do not mock modules or functions. No `vi.mock('../some-module')`, no stubbing individual exports, no replacing a data layer with a jest-style double.
+
 - Use real scoring logic with real inputs
 - Use real validation functions with real transfer data
-- Use real loader logic with in-memory or fixture data substituted at the boundary (e.g. inject a fake Sheets client that returns fixture data, rather than mocking `fetch` or individual functions)
+- Use real loader logic, with the substitution made at a boundary the system genuinely has
 
-The goal is that a passing test means the real behaviour works, not just that the wiring is correct.
+The goal is that a passing test means the real behaviour works, not just that the wiring is correct. Every module mock you write is a claim about how the code is assembled, and it goes stale the moment someone rearranges it.
+
+**The distinction that matters is not "mock vs no mock" — it is *where* you substitute.**
+
+Replacing a module is a fiction: you are asserting that some internal function exists and behaves a certain way. Replacing a **network response** is not a fiction — the network is a real boundary the app crosses, and something on the other side really does return bytes. Substituting there leaves all of your own code running.
+
+### MSW is the standard for anything crossing the network
+
+**Any test involving an HTTP request or response uses [MSW](https://mswjs.io/) (`msw/node`, `setupServer`).** This is the gold standard for this codebase, not a fallback.
+
+MSW intercepts at the network layer rather than patching `fetch`, so everything between your code and the wire still executes for real:
+
+- the real FPL client, including its URL building, headers and retry behaviour
+- the real `googleapis` Sheets client, including auth and its response parsing
+- the real error handling for a 500, a timeout, or a malformed payload
+
+That is strictly *more* real coverage than injecting a fake client, because a fake client skips all of the above and only proves that your interpretation code works when handed a perfect object.
+
+```ts
+// Good — substitute the network, run everything else for real
+const server = setupServer(
+    http.get('https://fantasy.premierleague.com/api/bootstrap-static/', () =>
+        HttpResponse.json(bootstrapFixture),
+    ),
+);
+
+// Bad — a fiction about how the module is built, stale after any refactor
+vi.mock('../../_shared/lib/fpl/api-cache');
+```
+
+**Test the unhappy paths too.** MSW makes them cheap and they are where real bugs live: a non-200, a payload missing a field, a network error. If a loader has never been tested against a 500 from FPL, nobody knows what a manager sees when FPL is down.
+
+**What MSW does not replace.** Passing fixture data straight into a pure function is still the right thing for scoring, validators and rules — there is no network there to intercept. Reach for MSW when the code under test genuinely makes a request.
 
 ### What to test
 
@@ -45,8 +78,9 @@ The goal is that a passing test means the real behaviour works, not just that th
 | `scoring/` | That given a stat line and a position, the correct points are calculated. Test edge cases in `POSITION_RULES` (e.g. saves threshold, goals conceded penalty). |
 | `transfers/` | That valid transfers are accepted and invalid ones are rejected. Test all `TransferType` variants. |
 | `draft/` | That snake draft order is generated correctly. That the same player cannot be picked twice in the same division. |
-| Route loaders | That the loader returns the correct shape of data for a given URL and division. |
+| Route loaders | That the loader returns the correct shape of data for a given URL and division. Use MSW for the Sheets/FPL calls underneath. |
 | `_shared/lib/` | Only the cache invalidation logic and TTL config — these have real business impact. |
+| FPL + Sheets clients | Behaviour against real payloads via MSW: a good response, a 500, a timeout, and a payload missing a field. These are the app's only external dependencies and the only place it can be broken by someone else. |
 
 ### Where tests live
 
@@ -133,3 +167,15 @@ Run tests with:
 ```bash
 yarn test
 ```
+
+**MSW** (`msw/node`) is the network boundary — see *MSW is the standard for anything crossing the network* above. A test that needs it starts a server per file and asserts every request was accounted for:
+
+```ts
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+`onUnhandledRequest: 'error'` is not optional. Without it a request you forgot to handle escapes to the real internet, and the test either hits live FPL or fails slowly and confusingly. With it, an unhandled request fails immediately and tells you which URL it was.


### PR DESCRIPTION
Corrects a rule that was ruling out the right tool.

## The problem

`testing-conventions.md` banned mocks, then named the alternative as *"inject a fake Sheets client that returns fixture data, rather than mocking `fetch` or individual functions"*. Read literally that rules MSW out — and it shouldn't, because MSW isn't doing the thing the rule is against.

**The distinction that matters is not "mock vs no mock" — it is *where* you substitute.**

Replacing a **module** is a fiction: it asserts that some internal function exists and behaves a certain way, and it goes stale the moment someone rearranges the code. Replacing a **network response** is not a fiction — the network is a boundary the app genuinely crosses, and something on the other side really does return bytes.

MSW intercepts at that boundary, so everything between our code and the wire still executes for real: the FPL client's URL building and retries, the `googleapis` client's auth and response parsing, and all of our error handling. That is strictly **more** real coverage than injecting a fake client, which skips all of it and only proves the interpretation code works when handed a perfect object.

## What changed

- Rule renamed **"No module mocks — substitute at a real boundary"**, with the where-you-substitute distinction spelled out and a good/bad example.
- New section making MSW **the standard, not a fallback**, for any test involving an HTTP request or response.
- Calls out that the **unhappy paths are the point** — a 500, a timeout, a payload missing a field. Nobody currently knows what a manager sees when FPL is down.
- Says what MSW does **not** replace: pure functions still take fixtures directly, there is no network there to intercept.
- Framework section documents `setupServer` with `onUnhandledRequest: 'error'`, and why that flag is not optional (without it a forgotten handler escapes to the real internet).
- "What to test" gains a row for the FPL + Sheets clients — the app's only external dependencies, and the only place it can be broken by someone else.

## Backlog consequences

This changes a dependency, so both are recorded rather than left to be rediscovered:

**P3.4 (first loader test) is no longer hard-blocked on P2.3.** That block assumed an injection seam was the only way in. It isn't — MSW substitutes at the network boundary and the sheets modules can be imported exactly as they are.

Recorded honestly, it still costs a one-off setup: `_shared/lib/sheets/utils/common.ts` uses `google.auth.JWT`, which signs a JWT **locally** with `credentials.private_key` before exchanging it at `oauth2.googleapis.com/token`. So a test needs a fixture service account (throwaway RSA key — nothing verifies the signature) plus handlers for the token endpoint and `sheets.googleapis.com`. Write it once, every loader test reuses it. Also flagged: `common.ts` memoises the client in a module-scope `sheetsClientPromise` that survives between tests, the same singleton problem already logged against `DataCacheService`.

**P2.3's rationale corrected.** It claimed to be *what unblocks P3.4*, on the basis that a row-returning reader is trivial to fake. That is no longer the argument. P2.3 still stands on its own terms — Rule 1, `_shared` must not import a domain — but the two items are now independent and can be done in either order.

**Issue #59** (MSW + red-green tests for the sheets layer) is now aligned with the conventions rather than in tension with them.

## Note

Docs only — no code, no dependency added. MSW is **not yet installed**; that comes with the first test that needs it (#59 or P3.4). 296 tests still pass and `yarn ratchet` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
