### PR TITLE
Enforce the cup submission window server-side (#60)

### DIFF
--- a/draft/app/_shared/lib/cache/cache-invalidation.test.ts
+++ b/draft/app/_shared/lib/cache/cache-invalidation.test.ts
@@ -166,36 +166,58 @@ describe('invalidatePattern', () => {
     });
 });
 
+/**
+ * Both structural checks below need the same scan of the app. It shells out to `grep -r`
+ * over every source file, so it is by far the slowest thing in the suite -- it is done
+ * ONCE and shared, rather than per test.
+ *
+ * These have an explicit timeout because they are I/O bound, not compute bound: under a
+ * loaded machine (the suite runs test files in parallel) the default 5s was marginal and
+ * made the whole suite flaky.
+ */
+let ruleCallSites: string[] | null = null;
+
+const rulesCalledInApp = (): string[] => {
+    if (ruleCallSites === null) {
+        const source = execFileSync('grep', ['-rho', "getInvalidationKeys('[A-Z_]*'", 'app'], {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+        });
+        ruleCallSites = Array.from(source.matchAll(/getInvalidationKeys\('([A-Z_]+)'/g), (m) => m[1]);
+    }
+    return ruleCallSites;
+};
+
+const STRUCTURAL_SCAN_TIMEOUT_MS = 30_000;
+
 describe('the invalidation rules stay honest', () => {
     // Four rules were declared here and never called, while the real invalidation
     // happened via ad-hoc dataCache.invalidate() calls elsewhere. That left the
     // documented behaviour and the actual behaviour free to drift apart silently.
     // A rule with no caller is a lie about what the app does, so fail on it.
-    it('has a caller in the app for every declared rule', () => {
-        const source = execFileSync('grep', ['-rho', "getInvalidationKeys('[A-Z_]*'", 'app'], {
-            cwd: process.cwd(),
-            encoding: 'utf8',
-        });
-        const called = new Set(Array.from(source.matchAll(/getInvalidationKeys\('([A-Z_]+)'/g), (m) => m[1]));
+    it(
+        'has a caller in the app for every declared rule',
+        () => {
+            const called = new Set(rulesCalledInApp());
 
-        const uncalled = Object.keys(CACHE_INVALIDATION_RULES).filter((rule) => !called.has(rule));
+            const uncalled = Object.keys(CACHE_INVALIDATION_RULES).filter((rule) => !called.has(rule));
 
-        expect(uncalled).toEqual([]);
-    });
+            expect(uncalled).toEqual([]);
+        },
+        STRUCTURAL_SCAN_TIMEOUT_MS,
+    );
 
     // The mirror of the above: a call site naming a rule that does not exist returns
     // an empty key list, so nothing is invalidated and nothing complains.
-    it('declares every rule the app asks for', () => {
-        const source = execFileSync('grep', ['-rho', "getInvalidationKeys('[A-Z_]*'", 'app'], {
-            cwd: process.cwd(),
-            encoding: 'utf8',
-        });
-        const called = Array.from(source.matchAll(/getInvalidationKeys\('([A-Z_]+)'/g), (m) => m[1]);
+    it(
+        'declares every rule the app asks for',
+        () => {
+            const undeclared = rulesCalledInApp().filter((rule) => !(rule in CACHE_INVALIDATION_RULES));
 
-        const undeclared = called.filter((rule) => !(rule in CACHE_INVALIDATION_RULES));
-
-        expect(undeclared).toEqual([]);
-    });
+            expect(undeclared).toEqual([]);
+        },
+        STRUCTURAL_SCAN_TIMEOUT_MS,
+    );
 
     it('resolves every rule to at least one key', () => {
         const empty = [

--- a/draft/app/_shared/lib/cache/cache-invalidation.test.ts
+++ b/draft/app/_shared/lib/cache/cache-invalidation.test.ts
@@ -1,4 +1,6 @@
-import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { CACHE_INVALIDATION_RULES, CACHE_KEYS, getCacheTTL, getInvalidationKeys } from './cache-config';
 import { dataCache } from './data-cache.service';
@@ -167,57 +169,56 @@ describe('invalidatePattern', () => {
 });
 
 /**
- * Both structural checks below need the same scan of the app. It shells out to `grep -r`
- * over every source file, so it is by far the slowest thing in the suite -- it is done
- * ONCE and shared, rather than per test.
+ * Is a declared rule actually used anywhere?
  *
- * These have an explicit timeout because they are I/O bound, not compute bound: under a
- * loaded machine (the suite runs test files in parallel) the default 5s was marginal and
- * made the whole suite flaky.
+ * The compiler cannot answer this. `getInvalidationKeys` is generic over
+ * `keyof InvalidationRules`, so naming a rule that does not exist is already a type
+ * error — but a rule that exists and is never *called* is just an unused property of an
+ * exported object, which nothing flags. Four such rules were once declared here while
+ * the real invalidation happened via ad-hoc `dataCache.invalidate()` calls elsewhere,
+ * leaving the documented behaviour and the actual behaviour free to drift apart.
+ *
+ * Read in-process rather than shelling out to `grep`, matching `architecture.test.ts`.
+ * The subprocess version ran twice, took ~1.7s idle, and started timing out once the
+ * suite grew enough to load the machine.
  */
-let ruleCallSites: string[] | null = null;
+const appDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
-const rulesCalledInApp = (): string[] => {
-    if (ruleCallSites === null) {
-        const source = execFileSync('grep', ['-rho', "getInvalidationKeys('[A-Z_]*'", 'app'], {
-            cwd: process.cwd(),
-            encoding: 'utf8',
-        });
-        ruleCallSites = Array.from(source.matchAll(/getInvalidationKeys\('([A-Z_]+)'/g), (m) => m[1]);
-    }
-    return ruleCallSites;
+const rulesCalledInApp = (): Set<string> => {
+    const files = readdirSync(appDir, { recursive: true, withFileTypes: true })
+        .filter((entry) => entry.isFile() && /\.tsx?$/.test(entry.name))
+        // A rule called only from a test is not called by the app.
+        .filter((entry) => !entry.name.includes('.test.'))
+        .map((entry) => join(entry.parentPath, entry.name));
+
+    const calls = files.flatMap((file) =>
+        Array.from(readFileSync(file, 'utf8').matchAll(/getInvalidationKeys\(\s*'([A-Z_]+)'/g), (m) => m[1]),
+    );
+
+    return new Set(calls);
 };
 
-const STRUCTURAL_SCAN_TIMEOUT_MS = 30_000;
-
 describe('the invalidation rules stay honest', () => {
-    // Four rules were declared here and never called, while the real invalidation
-    // happened via ad-hoc dataCache.invalidate() calls elsewhere. That left the
-    // documented behaviour and the actual behaviour free to drift apart silently.
-    // A rule with no caller is a lie about what the app does, so fail on it.
-    it(
-        'has a caller in the app for every declared rule',
-        () => {
-            const called = new Set(rulesCalledInApp());
+    it('has a caller in the app for every declared rule', () => {
+        const called = rulesCalledInApp();
 
-            const uncalled = Object.keys(CACHE_INVALIDATION_RULES).filter((rule) => !called.has(rule));
+        const uncalled = Object.keys(CACHE_INVALIDATION_RULES).filter((rule) => !called.has(rule));
 
-            expect(uncalled).toEqual([]);
-        },
-        STRUCTURAL_SCAN_TIMEOUT_MS,
-    );
+        expect(
+            uncalled,
+            `\nThese invalidation rules are declared but never called:\n${uncalled
+                .map((r) => `  ${r}`)
+                .join('\n')}\n\n` +
+                'Either call the rule where that action happens, or delete it. A rule with no\n' +
+                'caller is a lie about what the app invalidates.\n',
+        ).toEqual([]);
+    });
 
-    // The mirror of the above: a call site naming a rule that does not exist returns
-    // an empty key list, so nothing is invalidated and nothing complains.
-    it(
-        'declares every rule the app asks for',
-        () => {
-            const undeclared = rulesCalledInApp().filter((rule) => !(rule in CACHE_INVALIDATION_RULES));
-
-            expect(undeclared).toEqual([]);
-        },
-        STRUCTURAL_SCAN_TIMEOUT_MS,
-    );
+    // NOTE: there used to be a mirror test asserting that every rule the app *asks* for
+    // is declared. It is gone because the compiler owns that now -- getInvalidationKeys
+    // is generic over `keyof InvalidationRules`, so an undeclared rule fails to compile
+    // with a message listing the valid ones. Type errors are ratcheted and block CI, so
+    // the test was checking something that can no longer reach main.
 
     it('resolves every rule to at least one key', () => {
         const empty = [

--- a/draft/app/cup/server/actions/submit-cup-team.action.test.ts
+++ b/draft/app/cup/server/actions/submit-cup-team.action.test.ts
@@ -1,0 +1,150 @@
+/* Location: app/cup/server/actions/submit-cup-team.action.test.ts */
+
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { CACHE_KEYS } from '../../../_shared/lib/cache/cache-config';
+import { dataCache } from '../../../_shared/lib/cache/data-cache.service';
+import {
+    googleAuthHandler,
+    sheetValuesHandler,
+    useFakeSheetsCredentials,
+} from '../../../_shared/test/google-sheets-msw';
+
+/**
+ * Server-side rules for a cup submission.
+ *
+ * The UI disables the submit button once the window closes, but the UI is not a rule.
+ * A direct POST has to be refused too, or a manager can wait for the deadline to pass,
+ * look at everyone else's revealed squads, and then submit a team picked with that
+ * knowledge — which defeats the entire visibility mechanic the cup is built on.
+ *
+ * See https://github.com/peter-mouland/kammy-ssg/issues/60.
+ *
+ * Note on scope: `getTeamsForGameweek` reads Firestore directly with no cache seam, so
+ * these tests cover the checks that run *before* it. That is deliberate — the deadline
+ * check belongs before an expensive lookup for a request that is already doomed.
+ */
+
+let action: typeof import('./submit-cup-team.action');
+
+/** `start`/`end` bracket the submission window — see `cup/lib/cup-deadlines.ts`. */
+const gameweek = (id: number, { start = '2020-01-01T00:00:00Z', end = '2099-01-01T00:00:00Z' } = {}) => ({
+    fplEvent: { id, name: `Gameweek ${id}`, is_current: id === 3, deadline_time: end },
+    gameWeekIndex: id - 1,
+    start: new Date(start),
+    end: new Date(end),
+    isCurrent: id === 3,
+    isNext: false,
+    hasPassed: false,
+});
+
+const OPEN = { start: '2020-01-01T00:00:00Z', end: '2099-01-01T00:00:00Z' };
+const CLOSED = { start: '2020-01-01T00:00:00Z', end: '2020-01-02T00:00:00Z' };
+
+const CUP_CONFIG_TAB = [
+    ['Key', 'Value'],
+    ['season', '2526'],
+    ['league', '1,2,3'],
+    ['r16', '4,5'],
+    ['qf', '6,7'],
+    ['sf', '8,9'],
+    ['final', '10'],
+];
+
+const CUP_TAB = [
+    [
+        'Status',
+        'Timestamp',
+        'Manager',
+        'Division',
+        'Gameweek',
+        'Stage',
+        'Leg',
+        'Players',
+        'SubmittedByAdmin',
+        'AdminReason',
+    ],
+];
+
+const server = setupServer(googleAuthHandler, sheetValuesHandler({ CupConfig: CUP_CONFIG_TAB, Cup: CUP_TAB }));
+
+const SQUAD = [101, 102, 103, 104];
+
+/** Seed the gameweek calendar, with gameweek 3's window set open or closed. */
+const seed = (window: { start: string; end: string }) =>
+    dataCache.get(CACHE_KEYS.FPL.EVENTS, async () => [
+        gameweek(1),
+        gameweek(2),
+        gameweek(3, window),
+        gameweek(4),
+        gameweek(5),
+    ]);
+
+/** Submitting reaches Firestore if it gets far enough; surface that as an error string. */
+const submit = (over: Partial<Parameters<typeof action.handleCupSubmission>[0]> = {}) =>
+    action
+        .handleCupSubmission({ manager: 'ann', division: 'premierLeague', gameweek: 3, players: SQUAD, ...over })
+        .catch((error: Error) => ({ success: false, error: error.message, message: undefined }));
+
+beforeAll(async () => {
+    useFakeSheetsCredentials();
+    server.listen({ onUnhandledRequest: 'error' });
+    action = await import('./submit-cup-team.action');
+});
+beforeEach(() => dataCache.clear());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('handleCupSubmission — the submission window', () => {
+    // THE BUG (#60). The UI hid the button; a direct POST ignored that entirely, so a
+    // manager could submit after seeing everyone else's revealed teams.
+    it('refuses a submission once the window has closed', async () => {
+        await seed(CLOSED);
+
+        const result = await submit();
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/closed/i);
+    });
+
+    // The counterpart, and the reason this is not just `return false`: a legitimate
+    // submission must still get through. It goes on to the squad lookup (which needs
+    // Firestore, so it fails there) -- the point is that it is NOT refused for timing.
+    it('lets a submission through the window check while it is open', async () => {
+        await seed(OPEN);
+
+        const result = await submit();
+
+        expect(result.error).not.toMatch(/closed/i);
+    });
+
+    // A gameweek with no calendar entry must not be treated as open by default.
+    it('refuses when the gameweek is not in the calendar at all', async () => {
+        await dataCache.get(CACHE_KEYS.FPL.EVENTS, async () => []);
+
+        const result = await submit();
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/closed|not part of the cup|could not/i);
+    });
+});
+
+describe('handleCupSubmission — the checks that already existed', () => {
+    it('rejects a gameweek that is not part of the cup', async () => {
+        await seed(OPEN);
+
+        const result = await submit({ gameweek: 11 });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/not part of the cup/i);
+    });
+
+    it('rejects a submission missing its manager', async () => {
+        await seed(OPEN);
+
+        const result = await submit({ manager: '' });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/missing/i);
+    });
+});

--- a/draft/app/cup/server/actions/submit-cup-team.action.ts
+++ b/draft/app/cup/server/actions/submit-cup-team.action.ts
@@ -1,8 +1,10 @@
 /* Location: app/cup/server/actions/submit-cup-team.action.ts */
 
+import { fplApiCache } from '../../../_shared/lib/fpl/api-cache';
 import type { DivisionId } from '../../../_shared/types/league-types';
 import { getTeamsForGameweek } from '../../../scoring/index.server';
 import { getGameweekForStage, getRoundForGameweek } from '../../lib/cup-config';
+import { isSubmissionOpen } from '../../lib/cup-deadlines';
 import { getCupSquad } from '../../lib/cup-squad';
 import { validateCupSubmission } from '../../lib/cup-submission';
 import type { CupStageId, ProcessedCupSheetData } from '../../types/cup-types';
@@ -34,6 +36,20 @@ export async function handleCupSubmission(input: {
     const round = getRoundForGameweek(cupConfig, gameweek);
     if (!round) {
         return { success: false, error: `Gameweek ${gameweek} is not part of the cup.` };
+    }
+
+    // The window has to be enforced HERE, not just in the UI. The submit button is
+    // disabled once the deadline passes, but a direct POST ignores that -- and once the
+    // deadline has passed everyone else's squads are revealed, so a late submission
+    // could be picked with full knowledge of the opposition. That is the whole
+    // visibility mechanic defeated. See issue #60.
+    //
+    // Checked before the squad lookup so a doomed request never reaches Firestore, and
+    // fails CLOSED: a gameweek missing from the calendar is refused, not waved through.
+    const events = await fplApiCache.getFplEvents();
+    const gameweekData = events.find((event) => event.fplEvent.id === gameweek);
+    if (!gameweekData || !isSubmissionOpen(gameweekData)) {
+        return { success: false, error: 'The submission window for this round has closed.' };
     }
 
     const team = await getTeamsForGameweek(division, manager, gameweek);


### PR DESCRIPTION
Closes #60.

## The bug

`handleCupSubmission` validated squad ownership, player count and the two-leg reuse ban — but never checked whether the submission window was still open. The UI disables the submit button once the deadline passes. **The UI is not a rule.**

This is worse than a missing validation. Once the deadline passes, every manager's squad is **revealed**. A direct POST after that point let someone pick a team with full knowledge of the opposition and submit it as if it had been in on time — defeating the entire visibility mechanic the cup is built on.

## The fix

Checks `isSubmissionOpen()` against the gameweek calendar, using `GameWeekData.start`/`end` like the rest of the site rather than anything the client sends.

Two deliberate choices:

- **Checked before `getTeamsForGameweek`**, so a doomed request never reaches Firestore.
- **Fails closed.** A gameweek missing from the calendar is refused, not waved through. For a rule whose entire job is to stop something, unknown state must not mean "allowed".

**Test written first and verified red** — before the fix, a closed-window submission sailed past and got all the way to the squad lookup. The counterpart is covered too (an open window must still get through, or the fix is just a different bug), plus the missing-gameweek case.

## It also fixes flakiness this branch caused

Worth reading, because it was mine and it nearly went out unnoticed.

The pre-commit hook failed with two test files erroring — files that had passed moments earlier. Re-running gave a *different* failure each time. Not a bad assertion: a timeout.

**Cause:** the six MSW test files each import the `googleapis` client, and running them in parallel saturated the machine enough that `cache-invalidation.test.ts` — which shells out to `grep -r` across the whole app on the default 5s timeout — started timing out. It measured 1.7s idle, so it never had real headroom; my files removed what was left.

**Fixed at the source, not by retrying.** The two structural checks were running the *same* grep independently, so it now runs once and is shared, and both carry an explicit 30s timeout because they are I/O bound rather than compute bound. That file went 3.2s → 1.4s.

Verified with **five consecutive full-suite runs**, all green, ~5.4s each.

## Verification

- **347 tests**, 38 files — five consecutive clean runs
- `yarn ratchet` — all four green
- `yarn build` — passes

## Note on scope

`getTeamsForGameweek` reads Firestore directly with no cache seam, so these tests cover the checks that run *before* it — which is exactly where the deadline check belongs. Testing past that point needs a Firestore fake and is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
