### PR TITLE
refactor(shared): promote gameweek-selector out of the teams domain

### DIFF
--- a/.kiro/backlog.md
+++ b/.kiro/backlog.md
@@ -28,9 +28,11 @@ git log --oneline -15
 
 | | Why |
 |---|---|
-| **P2.7 — public API for `transfers`, then the rest** | `draft` and `scoring` are done and are the worked examples. `MAY_REACH_INSIDE` is down to 21; the biggest remaining clusters are `players/components/player` (7 importers) and `teams/components/gameweek-selector` (5), which are P2.5 rather than P2.7. |
+| **P2.1b — move the data kernel** | Not just its own item: it is what **unblocks the rest of P2.5**. `players/components/player` has 8 importers, the biggest cluster left, but it cannot move to `_shared/components/` until `EnhancedPlayerData` and `RosterPlayer` are in the kernel — moving it today would add new `_shared` → domain edges and push that count back up from 3. |
+| **P2.5 — `players/components/player`** | Straight after P2.1b. 8 allowlist entries, and it dissolves the `players ↔ wishlist` cycle. |
+| **P2.7 — public API for `transfers`, then the rest** | `draft` and `scoring` are done and are the worked examples. Clears the remaining 9, but 1–2 per domain. |
 
-*Recently done: P4.5 (steering realigned + drift check), P3.3 (draft/lib now has 47 tests), P2.7 for `draft` (first public API), P2.3 (every sheets reader is now domain-free).*
+*Recently done: P2.5 for `gameweek-selector` (`MAY_REACH_INSIDE` 21 → 17), P4.5 (steering realigned + drift check), P3.3 (draft/lib now has 47 tests), P2.7 for `draft` (first public API), P2.3 (every sheets reader is now domain-free).*
 
 **Working agreements that are not obvious from the code:**
 - Consumer-focused tests that survive refactoring come **before** the refactor they protect. We violated this early and it cost us.
@@ -109,6 +111,7 @@ Re-measure with `yarn ratchet` and `yarn test`. Committed counts live in `.ratch
 | Root `yarn type-check` | fails: `command not found: tsc` | works |
 | Pre-commit hook | never ran (see P0.6) | runs lint-staged + tests |
 | `_shared` → domain imports | 34, across 6 domains | **3** — P2.1 + P2.4 + P2.7 (draft) + P2.3 complete; the rest is P2.1b |
+| Domain → another domain's internals | 34 | **17** — P2.7 (draft, scoring) thirteen, P2.5 (`gameweek-selector`) four |
 | Architecture rules enforced | 0 | **5** (P1.2, P4.5) |
 | Domain dependency cycles | 15 | **10** — P2.4 two, P2.7 (draft) one, P2.3 two |
 
@@ -197,7 +200,7 @@ The highest-leverage phase. Nothing after this is safe without it.
   Failure messages name the file, the rule, and what to do about it. Verified in both directions: a probe import into `_shared/` was caught, and a fake allowlist entry was reported as stale.
   *Still to add after P4.1:* every `*.route.tsx` has a sibling `*.page.tsx`.
 
-  **The two allowlists are now the Phase 2 worklist.** Note how concentrated they are — `players/components/player` (7 importers), `teams/components/gameweek-selector` (5) and `scoring/server/services/division-teams.service` (6) account for 18 of the 34 internal-reach violations.
+  **The two allowlists are now the Phase 2 worklist.** Note how concentrated they are — `players/components/player` (8 importers), `scoring/server/services/division-teams.service` (6) and `teams/components/gameweek-selector` (4) account for 18 of the 34 internal-reach violations.
 
 - [ ] **P1.3 — Burn down type errors, one PR per domain, ascending cost**
   Order: `leagues` (10) → `api` (7) + `wishlist` (1) → `scoring` (15) → `_shared` (26) → `teams` (30) → `players` (34) → `draft` (36) → `transfers` (51) → `admin` (63).
@@ -443,9 +446,32 @@ The real DDD work. Large, but correct — and it is what unblocks route-loader t
   *Acceptance (whole item):* each domain has an `index.ts`; `MAY_REACH_INSIDE` is empty; `TRANSITIONAL_PUBLIC_SEGMENTS` is empty, making the index the only cross-domain entry point.
   *Note:* `TRANSITIONAL_PUBLIC_SEGMENTS` is global, so it cannot come out until every domain has an index. `draft`'s own `types/` and `lib/` are still imported directly by `admin`, `players`, `transfers` and `scoring` — legal for now, and a tidy-up for when the flag goes.
 
-- [ ] **P2.5 — Promote genuinely shared components**
+- [~] **P2.5 — Promote genuinely shared components**
   `teams/components/gameweek-selector` is used by transfers, leagues, players and admin. `players/components/player` is used by teams, transfers, admin and wishlist. Both belong in `_shared/components/`.
   *Acceptance:* no domain imports another domain's `components/`; `architecture.test.ts` enforces it.
+
+  ### ✅ `gameweek-selector` — done
+
+  Moved to `_shared/components/` with `git mv`, so history follows it. **`MAY_REACH_INSIDE` 21 → 17.** Five importers updated — the four cross-domain ones plus `teams/components/team-view.tsx`, which owned it.
+
+  It qualified without argument: its entire import list was react-router, `_shared/lib/fpl/fpl-types` and its own stylesheet — **zero domain imports** — so this was a move and four path rewrites, with no judgement call about what it means. A gameweek picker is not teams-domain UI; it only lived there because `teams` happened to need it first.
+
+  *No cycle dissolved.* `teams ↔ leagues` survives it: `leagues/server/team-of-the-week.server.ts -> teams/types/team-types` is the other edge and is untouched by this.
+
+  ### `players/components/player` — blocked on P2.1b
+
+  The bigger half (8 importers) is **not** a like-for-like follow-up, and doing it next would go backwards.
+
+  [player.tsx](../draft/app/players/components/player.tsx) imports `EnhancedPlayerData` (`scoring/types`) and `DisplayablePlayer` (`players/types`), and `DisplayablePlayer` is itself `EnhancedPlayerData & RosterPlayer`. Moving the file into `_shared/components/` therefore adds new `_shared` → domain edges, taking `SHARED_MAY_IMPORT` from **3 back to ~5** — reversing the metric Phase 2 has driven from 34. Those are exactly P2.1b's types, so P2.1b is the unblock.
+
+  **There is also a real design question here, and P2.5 assumed the answer.** P2.7 for `scoring` set the opposite precedent: its components were *exposed via the index* rather than promoted, because explaining a points figure is scoring's job. Rendering a player card arguably fails that test the same way. Both routes clear the same 8 entries:
+
+  | | Blocked on P2.1b? | `players ↔ wishlist` cycle |
+  |---|---|---|
+  | Expose via `players/index.ts` (P2.7) | no | survives |
+  | Move to `_shared/components/` (P2.5) | yes | **dissolves** |
+
+  The cycle point decides it: `wishlist/components/wishlist-details.tsx -> players/components/player` is wishlist's **only** outbound edge to `players`, so moving the file kills that direction outright. Worth P2.1b first to get it.
 
 - [ ] **P2.6 — Confirm the cycles are gone**
   `scoring ↔ players`, `scoring ↔ teams`, `scoring ↔ transfers`, `teams ↔ leagues`, `players ↔ wishlist`, `players ↔ draft` should all dissolve once P2.1–P2.5 land. Anything left is a genuine modelling problem and needs a decision, not a move.

--- a/draft/app/_shared/components/gameweek-selector.module.css
+++ b/draft/app/_shared/components/gameweek-selector.module.css
@@ -1,4 +1,4 @@
-/* Location: app/teams/components/gameweek-selector.module.css */
+/* Location: app/_shared/components/gameweek-selector.module.css */
 
 .gameweekSelector {
     display: flex;

--- a/draft/app/_shared/components/gameweek-selector.tsx
+++ b/draft/app/_shared/components/gameweek-selector.tsx
@@ -1,10 +1,9 @@
-/* Location: app/teams/components/gameweek-selector.tsx */
+/* Location: app/_shared/components/gameweek-selector.tsx */
 
-// /teams/components/gameweek-selector.tsx
 import type React from 'react';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router';
-import type { GameWeekData } from '../../_shared/lib/fpl/fpl-types';
+import type { GameWeekData } from '../lib/fpl/fpl-types';
 import styles from './gameweek-selector.module.css';
 
 interface GameweekSelectorProps {

--- a/draft/app/admin/components/sections/transfers-section.tsx
+++ b/draft/app/admin/components/sections/transfers-section.tsx
@@ -3,12 +3,12 @@
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import { useFetcher, useNavigate } from 'react-router';
+import { GameweekSelector } from '../../../_shared/components/gameweek-selector';
 import { SelectDivision } from '../../../_shared/components/select-division';
 import { Table, type TableColumn } from '../../../_shared/components/table';
 import type { FplTeam, GameWeekData } from '../../../_shared/lib/fpl/fpl-types';
 import type { DivisionSheetData, ManagerId, PositionSlotKey } from '../../../_shared/types/league-types';
 import { PlayerSummary } from '../../../players/components/player';
-import { GameweekSelector } from '../../../teams/components/gameweek-selector';
 import type { RosterPlayer } from '../../../teams/types/team-types';
 import { LoanStatusDisplay } from '../../../transfers/components/loan-status-display';
 import type { TransferAdminOverviewData, TransferValidationResult } from '../../../transfers/types/transfer-rule-types';

--- a/draft/app/architecture.test.ts
+++ b/draft/app/architecture.test.ts
@@ -161,17 +161,14 @@ const PUBLIC_SEGMENTS = [...PUBLIC_API_ENTRYPOINTS, ...TRANSITIONAL_PUBLIC_SEGME
 
 const MAY_REACH_INSIDE: ReadonlySet<string> = new Set([
     'admin/components/sections/transfers-section.tsx -> players/components/player',
-    'admin/components/sections/transfers-section.tsx -> teams/components/gameweek-selector',
     'admin/components/sections/transfers-section.tsx -> transfers/components/loan-status-display',
     'admin/server/services/system-status.service.ts -> transfers/server/services/transfers-data.service',
     'admin/server/transfers-admin.server.tsx -> transfers/server/services/transfers-data.service',
     'draft/server/draft.server.ts -> admin/server/actions/team-commit-actions',
     'homepage/homepage.route.tsx -> leagues/server/league-standings.server',
     'homepage/home.page.tsx -> leagues/components/position-points-table',
-    'leagues/league-standings.tsx -> teams/components/gameweek-selector',
     'players/components/player-stats-table.tsx -> wishlist/components/wishlist-button',
     'players/components/player-stats-table.tsx -> wishlist/components/wishlist-tags',
-    'players/players.page.tsx -> teams/components/gameweek-selector',
     'teams/components/all-teams-table.tsx -> players/components/player',
     'teams/components/position-slot-card.tsx -> players/components/player',
     'teams/server/team.server.tsx -> leagues/server/team-of-the-week.server',
@@ -179,7 +176,6 @@ const MAY_REACH_INSIDE: ReadonlySet<string> = new Set([
     'transfers/components/loan-status-display.tsx -> players/components/player',
     'transfers/components/transfer-form.tsx -> players/components/player',
     'transfers/components/transfer-selector-stat-columns.tsx -> players/components/player',
-    'transfers/transfers.page.tsx -> teams/components/gameweek-selector',
     'wishlist/components/wishlist-details.tsx -> players/components/player',
 ]);
 

--- a/draft/app/leagues/league-standings.tsx
+++ b/draft/app/leagues/league-standings.tsx
@@ -1,12 +1,12 @@
 /* Location: app/leagues/league-standings.tsx */
 
 import { useLoaderData, useNavigate, useSearchParams } from 'react-router';
+import { GameweekSelector } from '../_shared/components/gameweek-selector';
 import { PageHeader } from '../_shared/components/page-header';
 import { SelectDivision } from '../_shared/components/select-division';
 import { TimeTravelBanner } from '../_shared/components/time-travel-banner';
 import { UserSelectionProvider } from '../_shared/features/user-selection/user-selection-provider';
 import type { DivisionId } from '../_shared/types/league-types';
-import { GameweekSelector } from '../teams/components/gameweek-selector';
 import { PositionPointsTable } from './components/position-points-table';
 import type { EnhancedLeagueStandingsLoaderData } from './types/league-standings-types';
 

--- a/draft/app/players/players.page.tsx
+++ b/draft/app/players/players.page.tsx
@@ -2,9 +2,9 @@
 
 // app/routes/players.tsx
 import { useLoaderData } from 'react-router';
+import { GameweekSelector } from '../_shared/components/gameweek-selector';
 import { PageHeader } from '../_shared/components/page-header';
 import { ScoringInfo } from '../scoring';
-import { GameweekSelector } from '../teams/components/gameweek-selector';
 import { PlayerStatsTable } from './components/player-stats-table';
 import type { PlayerStatsData } from './types/player-types';
 

--- a/draft/app/teams/components/team-view.tsx
+++ b/draft/app/teams/components/team-view.tsx
@@ -1,13 +1,13 @@
 // app/teams/components/team-view.tsx
 
 import { Link, useLoaderData, useNavigate, useSearchParams } from 'react-router';
+import { GameweekSelector } from '../../_shared/components/gameweek-selector';
 import { PageHeader } from '../../_shared/components/page-header';
 import { SelectUser } from '../../_shared/components/select-user';
 import { TimeTravelBanner } from '../../_shared/components/time-travel-banner';
 import { UserSelectionProvider } from '../../_shared/features/user-selection/user-selection-provider';
 import type { StatsViewMode, TeamViewData } from '../types/team-types';
 import type { TeamViewTab } from '../types/team-view-types';
-import { GameweekSelector } from './gameweek-selector';
 import { TeamOfTheWeek } from './team-of-the-week';
 import styles from './team-view.module.css';
 import { AllTeamsView } from './team-view-all-teams';

--- a/draft/app/transfers/transfers.page.tsx
+++ b/draft/app/transfers/transfers.page.tsx
@@ -2,12 +2,12 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useLoaderData, useSearchParams } from 'react-router';
+import { GameweekSelector } from '../_shared/components/gameweek-selector';
 import { PageHeader } from '../_shared/components/page-header';
 import { SelectUser } from '../_shared/components/select-user';
 import { TimeTravelBanner } from '../_shared/components/time-travel-banner';
 import { UserSelectionProvider } from '../_shared/features/user-selection/user-selection-provider';
 import type { ManagerId, PositionSlotKey } from '../_shared/types/league-types';
-import { GameweekSelector } from '../teams/components/gameweek-selector';
 import type { RosterPlayer } from '../teams/types/team-types';
 import { CurrentTransfers } from './components/current-transfers';
 import { LoanStatusDisplay } from './components/loan-status-display';


### PR DESCRIPTION
**P2.5**, first half. `MAY_REACH_INSIDE` **21 → 17**.

Four domains — `admin`, `leagues`, `players` and `transfers` — imported `GameweekSelector` from `teams/components/`, each one allowlisted in `architecture.test.ts` as reaching inside another domain. Those four entries are now deleted; the paired stale-entry test enforces that they had to be.

### Why this one was uncontroversial

Its entire import list was react-router, `_shared/lib/fpl/fpl-types` and its own stylesheet — **zero domain imports**. So this is a `git mv` plus five path rewrites, with no judgement call about what the component means. A gameweek picker is not teams-domain UI; it only lived in `teams/` because that domain needed it first.

Both files are staged as renames, so `git log --follow` still works on them.

The fifth importer is `teams/components/team-view.tsx`, which owned it and used a local `./gameweek-selector` path.

**No cycle dissolved.** `teams ↔ leagues` survives on `leagues/server/team-of-the-week.server.ts -> teams/types/team-types`, which this doesn't touch.

### What is deliberately not in here

The larger half of P2.5 — `players/components/player`, **8 importers** — is blocked.

`player.tsx` imports `EnhancedPlayerData` (`scoring/types`) and `DisplayablePlayer` (`players/types`), and `DisplayablePlayer` is itself `EnhancedPlayerData & RosterPlayer`. Moving it into `_shared/components/` today would add new `_shared` → domain edges, taking `SHARED_MAY_IMPORT` from **3 back to ~5** — reversing the metric Phase 2 has driven down from 34. Those are exactly P2.1b's types, so **P2.1b is the unblock**.

There is also an unmade design decision recorded in the backlog: P2.7 for `scoring` set the opposite precedent (expose components via the index rather than promote them). Both routes clear the same 8 entries, but only the move dissolves the `players ↔ wishlist` cycle — `wishlist-details.tsx -> players/components/player` is wishlist's only outbound edge to `players`. That is what settles it in favour of waiting for P2.1b.

### Verification

| | |
|---|---|
| `yarn test` | 346 passing, 38 files — unchanged |
| `yarn ratchet` | types 176, functions 0, CSS 175, lint 266 — **all unchanged**, correct for a pure move |
| `yarn build` | clean, incl. the `functions` compile |
| `yarn check` | back to master's baseline |

One thing worth knowing: `yarn check` went 1 error → 6 after the move, because Biome's `organizeImports` wanted the new `_shared/...` paths resorted in all five files. `yarn test` and `yarn ratchet` were both green throughout — the ratchet counts lint *warnings*, not errors — so neither would have caught it.

Also updates the backlog: P2.5 marked in-progress with this half recorded, the blocked-on-P2.1b analysis written up, the stale 7/5 importer split corrected to 8/4, and a new baseline row so this count is tracked like the others.

**[Separate problem found]** — unrelated and untouched: `biome.json` itself has a formatting error on master. It survives because the pre-commit hook runs lint-staged over *staged* files only, so nothing checks it unless you edit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)