### PR TITLE
docs: correct stale division facts, add a handover

### DIFF
--- a/.kiro/handover.md
+++ b/.kiro/handover.md
@@ -1,0 +1,80 @@
+# Handover — where things stand, 2026-08-01
+
+Written for whoever picks this up next. **Not a steering file**: read it once at the start, then
+work from the documents it points at.
+
+---
+
+## The one-paragraph version
+
+The app was returning 500s and nobody could tell whether the code or the data was at fault. That is
+now answered: an offline fixture harness (`yarn dev:fixtures`) runs the whole site from
+`test-fixtures/` and renders every route, which proves the code path. Along the way the harness
+found three real production bugs, all now fixed and deployed. **Production is live and error-free,
+but its Firestore is empty**, so four pages show a "not loaded yet" explanation rather than data.
+Filling it is the next job and it is an ops task, not a coding one.
+
+## State
+
+| | |
+|---|---|
+| branch | `master`, clean, everything merged ([PR #118](https://github.com/peter-mouland/kammy-ssg/pull/118)) |
+| tests | 524 passing, 52 files |
+| ratchet | types 174 · css 175 · biome 266 — all at baseline, types one *better* |
+| production | https://draft-ff.web.app — deployed, 0 error pages |
+
+Verify with `yarn test`, `yarn ratchet`, `yarn build`. Run `yarn build` before committing: it is the
+only thing that type-checks the `functions` workspace.
+
+## What exists now that did not before
+
+- **`yarn dev:fixtures`** — the real app on port 3100, served entirely from `test-fixtures/`, no
+  credentials, with the date as a URL parameter (`?now=2025-01-10`). Read *Running it locally* in
+  [architecture.md](steering/architecture.md).
+- **An in-memory Firestore** (`_shared/lib/firestore-cache/firestore-memory.ts`) behind
+  `KAMMY_FIXTURE_FIRESTORE=1`. MSW cannot intercept gRPC and the emulator needs Java.
+- **MSW handlers over the fixtures** for Sheets and FPL, with a **writable** sheet store so form
+  actions can be exercised end to end.
+- **A clock** (`_shared/lib/clock.ts`). Use `now()` rather than `new Date()` at any decision site.
+- **A season rebuild** (`draft/harness/rebuild-season.ts`) — 117 documents through the app's own
+  pipeline in about 7 seconds, and proven clock-independent.
+- **Real error pages.** A failing loader now shows the whole cause chain and the specific error
+  code; expected states ("the season has ended") render as explanations, not crashes.
+
+## Do this next, in order
+
+1. **Populate production Firestore.** All four collections are empty, which is why `/leagues`,
+   `/teams`, `/transfers` and `/cup` return 503. Via `/admin`: populate bootstrap data → commit
+   teams per division → run points processing. **Do the greatScott division too** — it has no
+   `division-teams` documents at all, so its standings stay empty otherwise (G24).
+2. **Part E1 of the plan — the Playwright route crawl.** Every route at three dates, asserting 200,
+   no error boundary, no console error. This is the regression net the project still lacks, and the
+   fixture server already makes it cheap. See [testing-harness-plan.md](testing-harness-plan.md).
+3. **Then Part G** (loader payload tests) → **E2–E4** → **F** (Storybook) → **H** (contracts).
+
+Smaller, self-contained items are in the [gap register](testing-progress.md#gap-register); **G25**
+(untested admin orchestrator loop, untested `PositionPointsTable` prop) and **G1** (cup fixtures need
+authoring, and need a human decision) are the live ones.
+
+## Things that will cost you hours if you do not know them
+
+- **`test-fixtures/spreadsheets/` is the only copy of the 2025/26 season.** The live sheet has rolled
+  over. **Never run `fetch-season-fixtures.mjs 2526`** — it overwrites the fixtures with empty tabs.
+- **`archive/` is gitignored and irreplaceable.** FPL serves only the current season.
+- **Never assert exact points totals against fixtures.** The four defensive stats are invented for
+  every player. Assert behaviour and shape.
+- **The fixtures are a three-division season; the live sheet has four.** greatScott is code-covered
+  but not fixture-covered.
+- **What a division takes part in is data** — `promotion`/`relegation`/`cup` columns in the sheet.
+  Never derive it from `order`; greatScott sorts last and is in none of them, so rank-based logic
+  gets it exactly backwards.
+- **`createAppError()` returns a plain object, not an `Error`.** It fails every `instanceof Error`
+  check. This caused two separate bugs. `toErrorChain()` in `loader-error.ts` handles both shapes.
+- **A 500 in the harness is not automatically an app bug.** Of the two `/players` crashes it found,
+  one was app code and one was a missing step in the harness's own rebuild.
+- **MSW answers a request whether or not it is authenticated.** The entire Sheets suite stayed green
+  through a total auth outage. If you test a client, assert the auth header.
+- **`yarn ratchet` fails when a count goes DOWN too.** Run `yarn ratchet:update`, commit `.ratchet.json`.
+- **Never commit to master.** Branch, PR. Merging to master deploys to production.
+- **Kill dev servers by `@react-router/dev`**, not `"react-router dev"` — that string does not appear
+  in the process command line, so `pkill -f "react-router dev"` silently matches nothing.

--- a/.kiro/handover.md
+++ b/.kiro/handover.md
@@ -47,6 +47,22 @@ only thing that type-checks the `functions` workspace.
    `/teams`, `/transfers` and `/cup` return 503. Via `/admin`: populate bootstrap data → commit
    teams per division → run points processing. **Do the greatScott division too** — it has no
    `division-teams` documents at all, so its standings stay empty otherwise (G24).
+
+   **2026-08-02 — still not done. "Populate Bootstrap Data" fails.** It returned a bare
+   "Unexpected Server Error" page and wrote nothing (`players.json` still `[]`, checked past the
+   CDN). The cause was invisible by design: React Router substitutes that placeholder for any
+   unhandled server error, and `/admin`'s action read its form fields *outside* its own
+   try/catch, so the throw escaped as an unhandled 500 rather than becoming action data.
+   `requestFormData` indexed a load context that is `undefined` whenever Firebase does not parse
+   the body. Fixed in [PR #120](https://github.com/peter-mouland/kammy-ssg/pull/120) —
+   **retry the populate once that is merged and deployed**, and if it still fails the page will
+   name the real cause instead of hiding it. Update this line when it succeeds.
+
+   Ruled out while diagnosing, so nobody pays for it twice: the live data is fine (`Players`
+   sheet 558 rows, FPL bootstrap 564 elements, **558 matched by code**), and it is not the 60s
+   function timeout (element-summary fetches project to ~3s for all 558). `yarn dev:fixtures`
+   runs the identical action end to end without error, which is what established that this was
+   environment and not logic — the harness doing exactly the job it was built for.
 2. **Part E1 of the plan — the Playwright route crawl.** Every route at three dates, asserting 200,
    no error boundary, no console error. This is the regression net the project still lacks, and the
    fixture server already makes it cheap. See [testing-harness-plan.md](testing-harness-plan.md).
@@ -65,6 +81,12 @@ authoring, and need a human decision) are the live ones.
   every player. Assert behaviour and shape.
 - **The fixtures are a three-division season; the live sheet has four.** greatScott is code-covered
   but not fixture-covered.
+- **The fixtures cannot reproduce pre-season, and production is in it.** Live FPL is on the
+  2026/27 pre-season — 38 events, none `finished`, **no `is_current` at all** — so
+  `getCurrentGameweekData()` returns undefined and every `.fplEvent.id` on it is a crash site.
+  The captured 2024/25 bootstrap is a *finished* season whose frozen `is_current` (GW38) always
+  rescues the fallback, so no `?now=` reaches that state. Part E1's `preseason` scenario
+  (2024-08-01) yields a current **GW1** — it does not cover "no current gameweek anywhere".
 - **What a division takes part in is data** — `promotion`/`relegation`/`cup` columns in the sheet.
   Never derive it from `order`; greatScott sorts last and is in none of them, so rank-based logic
   gets it exactly backwards.

--- a/.kiro/handover.md
+++ b/.kiro/handover.md
@@ -48,21 +48,35 @@ only thing that type-checks the `functions` workspace.
    teams per division → run points processing. **Do the greatScott division too** — it has no
    `division-teams` documents at all, so its standings stay empty otherwise (G24).
 
-   **2026-08-02 — still not done. "Populate Bootstrap Data" fails.** It returned a bare
-   "Unexpected Server Error" page and wrote nothing (`players.json` still `[]`, checked past the
-   CDN). The cause was invisible by design: React Router substitutes that placeholder for any
-   unhandled server error, and `/admin`'s action read its form fields *outside* its own
-   try/catch, so the throw escaped as an unhandled 500 rather than becoming action data.
-   `requestFormData` indexed a load context that is `undefined` whenever Firebase does not parse
-   the body. Fixed in [PR #120](https://github.com/peter-mouland/kammy-ssg/pull/120) —
-   **retry the populate once that is merged and deployed**, and if it still fails the page will
-   name the real cause instead of hiding it. Update this line when it succeeds.
+   **2026-08-02 — attempted, failed, root cause fixed, not yet retried.** "Populate Bootstrap
+   Data" returned a bare "Unexpected Server Error" and wrote nothing. Two faults stacked, and
+   both are fixed and deployed:
+
+   - **`/admin`'s action hid every failure** ([PR #120](https://github.com/peter-mouland/kammy-ssg/pull/120)).
+     It read its form fields *outside* its own try/catch, so a throw escaped as an unhandled
+     500 — and React Router replaces that with its "Unexpected Server Error" placeholder in
+     production, so the cause reached nobody.
+   - **The real failure was a dependency version skew** ([PR #121](https://github.com/peter-mouland/kammy-ssg/pull/121)).
+     `draft` builds the SSR bundle but leaves `react`, `react-dom/server` and `react-router`
+     **external**, so production resolves them from `functions/node_modules` — which was on
+     react-router **7.6.1** and React **18** against a bundle built with **7.10.1** and React
+     **19**. 7.6.1's `singleFetchAction` still uses the old `unstable_respond` protocol, so
+     every fetcher submission to `/admin` came back `Error: Bad Request`. Caret ranges let it
+     drift; both workspaces now pin identical exact versions and
+     `harness/dependency-alignment.test.ts` fails if they diverge again.
+
+   **Retry the populate.** If it still fails, the page now names the cause.
 
    Ruled out while diagnosing, so nobody pays for it twice: the live data is fine (`Players`
-   sheet 558 rows, FPL bootstrap 564 elements, **558 matched by code**), and it is not the 60s
-   function timeout (element-summary fetches project to ~3s for all 558). `yarn dev:fixtures`
-   runs the identical action end to end without error, which is what established that this was
-   environment and not logic — the harness doing exactly the job it was built for.
+   sheet 558 rows, FPL bootstrap 564 elements, **558 matched by code**), and it was never the
+   60s function timeout (element-summary fetches project to ~3s for all 558).
+
+   **The harness could not have caught this, and the reason is worth knowing.** It copied
+   production's `getLoadContext: req => req.body` but had no body parser, so `req.body` was
+   `undefined` on every request — it replicated the shape of Firebase and not the behaviour,
+   which looks like coverage and is not. Firebase parses the body before the handler runs and
+   *consumes the stream*, so the Request the adapter builds is empty while its `Content-Type`
+   still promises form data. The harness now parses the same way.
 2. **Part E1 of the plan — the Playwright route crawl.** Every route at three dates, asserting 200,
    no error boundary, no console error. This is the regression net the project still lacks, and the
    fixture server already makes it cheap. See [testing-harness-plan.md](testing-harness-plan.md).

--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -6,7 +6,7 @@ inclusion: always
 
 ## What is this project?
 
-A draft-based fantasy football web app. Any anonymous user can join a league with friends. Each league week (gameweek), players earn points based on real-world football stats. Managers pick players in a snake draft — no player can be owned by more than one team within the same league. Managers can make transfers, trades, and loans within rules. At the end of the season, the winner is promoted and the loser is relegated across three divisions.
+A draft-based fantasy football web app. Any anonymous user can join a league with friends. Each league week (gameweek), players earn points based on real-world football stats. Managers pick players in a snake draft — no player can be owned by more than one team within the same league. Managers can make transfers, trades, and loans within rules. At the end of the season, the winner is promoted and the loser is relegated — across the divisions that take part in promotion and relegation, which is not all of them.
 
 ---
 
@@ -47,7 +47,7 @@ All league configuration and management decisions live here — managed by admin
 
 | Sheet | Purpose |
 |---|---|
-| `Divisions` | The three divisions (leagueOne, championship, premierLeague) |
+| `Divisions` | The divisions, and what each takes part in (`promotion`, `relegation`, `cup` columns) |
 | `UserTeams` | Manager → team → division assignments |
 | `Draft` | All draft picks (pickNumber, round, userId, playerId, divisionId) |
 | `DraftState` | Whether a draft is active and whose pick it is |
@@ -74,6 +74,19 @@ Backed by Firestore as a persistent cache to avoid hammering the FPL API.
 - **Firestore** — persistent cache for expensive FPL + scoring computations. Collections: `fpl-bootstrap`, `fpl-elements`, `division-teams`, `cache-state`
 - **Realtime Database** — live draft state sync between users during a live draft. Clients subscribe via `@firebase/database`
 
+### Substituting all three, offline
+`yarn dev:fixtures` runs the real app against `test-fixtures/` with no credentials — Sheets and FPL
+over MSW, Firestore swapped for an in-memory driver (`_shared/lib/firestore-cache/firestore-memory.ts`,
+gated on `KAMMY_FIXTURE_FIRESTORE=1`), and the season rebuilt at boot by `draft/harness/rebuild-season.ts`.
+The date is a URL parameter — see *Running it locally*. **Green there and red in production means the
+fault is data, not code.**
+
+### The clock
+`_shared/lib/clock.ts` is where "now" comes from; `new Date()` at a decision site is a bug waiting to
+happen. `clock.server.ts` adds `runWithNow` for per-request time travel and is split out because
+`node:async_hooks` cannot be in a browser bundle. Production sets no override, so `now()` is the real
+date there. Cache TTL arithmetic deliberately does **not** use it.
+
 ### In-Memory Cache
 `DataCacheService` in `_shared/lib/cache/` with per-key TTLs. Centralised config in `cache-config.ts` with invalidation rules per action type (e.g. `DRAFT_ACTION`, `TRANSFERS_PROCESSED`). TTL ranges from 30s (live transfers) to 24h (static reference data).
 
@@ -82,6 +95,15 @@ Backed by Firestore as a persistent cache to avoid hammering the FPL API.
 ## Domain Structure
 
 The `draft/app/` directory follows a **vertical domain + horizontal shared** layout. Features own their full slice (route, components, types, lib, server). Cross-cutting concerns live in `_shared/`.
+
+```
+kammy-ssg/
+├── test-fixtures/  # A whole season of captured data. Read-only, never imported by the app
+└── draft/
+    ├── harness/    # The offline fixture server + season rebuild. OUTSIDE app/ on purpose:
+    │               # it orchestrates several domains, which nothing in app/ may do
+    └── app/        # ↓ the domains below
+```
 
 ```
 draft/app/
@@ -114,9 +136,26 @@ If a pattern here disagrees with what you find elsewhere, `cup/` is more likely 
 ## Domain Model
 
 ### Divisions
-`DivisionId`: `'leagueOne' | 'championship' | 'premierLeague'`
+`DivisionId`: `'leagueOne' | 'championship' | 'premierLeague' | 'greatScott'`
 
-Three divisions. Winners of lower divisions are promoted; losers of upper divisions are relegated.
+**What a division takes part in is data, not something to infer from its id or its rank.** The
+`Divisions` sheet carries `promotion`, `relegation` and `cup` columns, read into
+`DivisionSheetData` and used via `_shared/lib/league-divisions.ts`.
+
+| division | order | promotion | relegation | cup |
+|---|---|---|---|---|
+| `premierLeague` | 1 | — (top) | ✅ | ✅ |
+| `championship` | 2 | ✅ | ✅ | ✅ |
+| `leagueOne` | 3 | ✅ | — (bottom of the pyramid) | ✅ |
+| `greatScott` | 4 | — | — | — |
+
+`greatScott` is standalone: it plays in nothing cross-division. **Do not derive these rules from
+`order`** — greatScott sorts last, so rank-based logic moves relegation onto it and off
+leagueOne, which is exactly backwards. This was inferred from the id (`!== 'premierLeague'`,
+`!== 'leagueOne'`) until a fourth division made that wrong.
+
+Adding a division means: the `DivisionId` union, `KNOWN_DIVISION_IDS`, and a row in the sheet.
+`/admin` shows a banner naming any division in the sheet the build does not recognise.
 
 ### Managers
 `ManagerId = string`. Each manager has a `userId`, `userName`, `teamName`, and belongs to one `divisionId`.

--- a/.kiro/testing-progress.md
+++ b/.kiro/testing-progress.md
@@ -41,7 +41,10 @@ reachable by any test. All three feel like "we have fixtures" and none of them i
 
 ## Scoreboard
 
-Baseline at the time of writing. These are the numbers that should move.
+**Last updated 2026-08-01, after the harness landed (PR #118).** 52 test files, 524 tests — up from
+38 files / 346 tests at the baseline below. The per-group numbers are the ones that should move; they
+are still largely at baseline because the harness built the *machinery* for Data/Render/Site coverage
+without yet writing the per-page tests (Parts E–G of the plan).
 
 | group | rows | Unit | Data | Render | Site |
 |---|---|---|---|---|---|

--- a/test-fixtures/README.md
+++ b/test-fixtures/README.md
@@ -69,6 +69,12 @@ Two things to know before trusting a number:
   [testing-progress.md](../.kiro/testing-progress.md)). The one submission's four players *are* present in
   `player-gw-points`, so scoring it works.
 
+**`divisions.json` carries the rule columns the live sheet gained.** `promotion`, `relegation` and
+`cup` per division — the real 2025/26 values for those three. `greatScott` is deliberately **not** in
+this fixture: it did not exist that season, and these files are that season. So the harness exercises a
+three-division league while the live sheet has four, which is why greatScott is code-covered
+(`league-divisions.test.ts`, `cup.route.test.ts`) but not fixture-covered.
+
 `players.json` is **cleaned, not raw** — see *Regenerating* below.
 
 ## `fpl/` — one element pool


### PR DESCRIPTION
Docs audit before handing over to a fresh agent. Found `architecture.md` wrong in the way that
matters most — it is loaded into **every** AI session, and still said `DivisionId` was a three-way
union and "the three divisions". An agent reading it would confidently write three-division code.

## architecture.md

- The division rules as a table, with the explicit warning **not** to derive them from `order` —
  greatScott sorts last and is in none of them, so rank-based logic gets it exactly backwards.
- What a division takes part in is **data** (the sheet's `promotion`/`relegation`/`cup` columns).
- The harness, the clock and `draft/harness/` now appear in the structure and data-source sections.
  Previously absent, so a new agent would not know `now()` exists and would keep reaching for
  `new Date()`.

## testing-progress.md

The scoreboard read as current when it was a baseline snapshot from before this work. Now dated,
with an honest note that the per-group numbers have barely moved: the harness built the *machinery*
for Data/Render/Site coverage without yet writing the per-page tests.

## test-fixtures/README.md

Documents the `promotion`/`relegation`/`cup` columns added to `divisions.json`, and that greatScott
is deliberately **absent** from the fixtures — so the harness exercises three divisions while the
live sheet has four.

## .kiro/handover.md (new)

State, what exists now that did not, what to do next in order, and the traps — including the ones
this session actually cost time on: `pkill -f "react-router dev"` matching nothing because the real
command line is `@react-router/dev/bin.js`, MSW answering unauthenticated requests (which is how a
total Sheets auth outage kept the suite green), and a 500 in the harness not automatically being an
app bug.

No code changes. 524 tests passing, ratchet unchanged on all four counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)