### PR TITLE
fix(admin): report why populating bootstrap data failed

### DIFF
--- a/draft/app/_shared/lib/form-data.test.ts
+++ b/draft/app/_shared/lib/form-data.test.ts
@@ -1,0 +1,79 @@
+/* Location: app/_shared/lib/form-data.test.ts */
+
+/**
+ * These cover the shapes the load context actually arrives in.
+ *
+ * `getLoadContext: (req) => req.body` (`functions/src/ssr.ts`) means the context is whatever
+ * Firebase's body parser produced -- an object for a content type it recognises, and
+ * `undefined` for one it does not. The undefined case used to throw *before* the calling
+ * action's try/catch, which is how a populate failure reached the browser as a bare
+ * "Unexpected Server Error" with the real cause nowhere.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { requestFormData } from './form-data';
+
+const formRequest = (fields: Record<string, string>) =>
+    new Request('http://localhost/admin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(fields).toString(),
+    });
+
+// Only `request` and `context` are read; the rest of ActionFunctionArgs is never touched.
+const call = (request: Request, context: unknown) =>
+    requestFormData({ request, context } as unknown as Parameters<typeof requestFormData>[0]);
+
+describe('requestFormData', () => {
+    it('reads a field from the request body when there is no load context', async () => {
+        const formData = await call(formRequest({ actionType: 'populateBootstrapData' }), undefined);
+
+        expect(formData.get('actionType')).toBe('populateBootstrapData');
+    });
+
+    it('does not throw when the load context is undefined', async () => {
+        // The regression. Firebase leaves `req.body` undefined for a body it did not parse,
+        // and indexing it took the whole action down before it could report anything.
+        const formData = await call(formRequest({}), undefined);
+
+        expect(() => formData.get('actionType')).not.toThrow();
+        expect(formData.get('actionType')).toBeUndefined();
+    });
+
+    it('prefers the load context, which is where Firebase leaves the parsed body', async () => {
+        // The request stream is already spent on Firebase, so the context is the only source.
+        const formData = await call(formRequest({}), { actionType: 'processGameweek' });
+
+        expect(formData.get('actionType')).toBe('processGameweek');
+    });
+
+    it('falls back to the request when the context has no such field', async () => {
+        const formData = await call(formRequest({ divisionId: 'greatScott' }), { actionType: 'processDraft' });
+
+        expect(formData.get('actionType')).toBe('processDraft');
+        expect(formData.get('divisionId')).toBe('greatScott');
+    });
+
+    it('returns undefined for a field neither source carries', async () => {
+        const formData = await call(formRequest({ actionType: 'processDraft' }), {});
+
+        expect(formData.get('gameweek')).toBeUndefined();
+    });
+
+    it('coerces a non-string context value, since a parsed body is not all strings', async () => {
+        const formData = await call(formRequest({}), { gameweek: 21 });
+
+        expect(formData.get('gameweek')).toBe('21');
+    });
+
+    it('survives a request whose body cannot be read as form data', async () => {
+        // Reading it twice is the cheapest way to produce a spent stream, which is the state
+        // Firebase hands over.
+        const request = formRequest({ actionType: 'systemHealthCheck' });
+        await request.formData();
+
+        const formData = await call(request, { actionType: 'systemHealthCheck' });
+
+        expect(formData.get('actionType')).toBe('systemHealthCheck');
+    });
+});

--- a/draft/app/_shared/lib/form-data.ts
+++ b/draft/app/_shared/lib/form-data.ts
@@ -2,16 +2,51 @@
 
 import type { ActionFunctionArgs } from 'react-router';
 
-export async function requestFormData({ request, context }: ActionFunctionArgs['context']): Promise<URLSearchParams> {
-    // does not work in firebase
-    const formData = await request.formData();
+/**
+ * Reading form fields the same way on Firebase and on React Router's own server.
+ *
+ * Firebase Functions parses the request body before the SSR handler ever sees it, so by the
+ * time `@react-router/express` rebuilds a `Request` the stream is already spent and
+ * `request.formData()` comes back empty. `functions/src/ssr.ts` works around that by passing
+ * the parsed body through as the load context, so the value is in one place or the other
+ * depending on where the app is running -- this reads whichever one has it.
+ *
+ * **`context` is not guaranteed to be an object.** It is `req.body`, and a request Firebase
+ * did not parse (an unrecognised content type, or an empty body) leaves it `undefined`.
+ * Indexing it directly threw `Cannot read properties of undefined` *before* the caller's
+ * try/catch could run, which surfaced as a bare "Unexpected Server Error" page with the real
+ * cause nowhere -- so the optional chaining below is load-bearing, not defensive habit.
+ */
+
+export interface ActionFormData {
+    /** The field's value, or `undefined` when neither source carries it. */
+    get(name: string): string | undefined;
+}
+
+/** Only the two fields this reads — every caller passes exactly these. */
+type FormDataSource = Pick<ActionFunctionArgs, 'request' | 'context'>;
+
+export async function requestFormData({ request, context }: FormDataSource): Promise<ActionFormData> {
+    // Spent on Firebase, populated everywhere else. Either way it must not throw: losing the
+    // body is recoverable via the context, losing the whole action is not.
+    let formData: FormData | null = null;
+    try {
+        formData = await request.formData();
+    } catch (error) {
+        console.warn('requestFormData: request.formData() failed, falling back to load context', error);
+    }
+
+    const fromContext = context as Record<string, unknown> | undefined;
+
     return {
         get: (name) => {
-            const v = context[name]; // needed for firebase
-            if (v) {
-                return v;
+            const contextValue = fromContext?.[name]; // needed for firebase
+            if (contextValue != null) {
+                return String(contextValue);
             }
-            return formData.get(name); // needed for react-router-v7
+
+            const formValue = formData?.get(name); // needed for react-router-v7
+            return typeof formValue === 'string' ? formValue : undefined;
         },
     };
 }

--- a/draft/app/admin/admin.route.tsx
+++ b/draft/app/admin/admin.route.tsx
@@ -14,7 +14,7 @@ import { requestFormData } from '../_shared/lib/form-data';
 import type { FplTeam } from '../_shared/lib/fpl/fpl-types';
 import { describeGameweekAvailability } from '../_shared/lib/gameweek-availability';
 import { describeUnknownDivisions } from '../_shared/lib/league-divisions';
-import { friendlyErrorResponse } from '../_shared/lib/loader-error';
+import { friendlyErrorResponse, toErrorChain } from '../_shared/lib/loader-error';
 import type { DivisionId } from '../_shared/types/league-types';
 import type { DraftAction } from '../draft';
 import type { TransferAdminOverviewData } from '../transfers';
@@ -113,32 +113,75 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 /**
+ * Every link in the cause chain, outermost first, as one line.
+ *
+ * `error.message` alone is what an admin used to get, and for a wrapped failure it is the
+ * least useful link in the chain: `SHEET_READ_ERROR` says a read gave up, the 403 three
+ * levels beneath it says why. `toErrorChain` unwraps both shapes this codebase throws --
+ * real `Error`s via `cause`, and `createAppError()`'s plain objects via `details`.
+ */
+function describeActionFailure(error: unknown): string {
+    const chain = toErrorChain(error);
+    if (chain.length === 0) return 'Unknown error occurred';
+
+    return chain.map((link) => (link.code ? `${link.code}: ${link.message}` : link.message)).join(' → ');
+}
+
+/**
  * Unified action handler for all admin operations using the orchestrator
+ *
+ * **Everything is inside the try, including reading the form.** It used to start outside it,
+ * and a throw there -- `requestFormData` indexing an undefined load context -- escaped as an
+ * unhandled 500. React Router replaces that with a bare "Unexpected Server Error" before it
+ * reaches the browser, so the admin saw a blank error page and the cause reached nobody.
+ * An admin action should always come back as action data the page can render.
  */
 export async function action({ request, context }: ActionFunctionArgs) {
-    const formData = await requestFormData({ request, context });
-    const actionType = formData.get('actionType')?.trim();
-    const divisionId = formData.get('divisionId')?.trim() as DivisionId;
-    const draftActionType = formData.get('draftAction')?.trim() as DraftAction;
-    const gameweekActionType = formData.get('gameweekAction')?.trim() || 'all';
-    const gameweek = Number.parseInt(formData.get('gameweek') as string, 10) || undefined;
-    if (!actionType) {
-        return data<AdminActionData>({
-            success: false,
-            error: 'Action type is required',
-        });
-    }
-
-    const { AdminOrchestrator } = await import('./server/services/admin-orchestrator.service');
-    const orchestrator = new AdminOrchestrator();
-
-    let result: AdminActionData;
+    let actionType: string | undefined;
 
     try {
+        const formData = await requestFormData({ request, context });
+        actionType = formData.get('actionType')?.trim();
+        const divisionId = formData.get('divisionId')?.trim() as DivisionId;
+        const draftActionType = formData.get('draftAction')?.trim() as DraftAction;
+        const gameweekActionType = formData.get('gameweekAction')?.trim() || 'all';
+        const gameweek = Number.parseInt(formData.get('gameweek') as string, 10) || undefined;
+
+        if (!actionType) {
+            return data<AdminActionData>({
+                success: false,
+                error: 'Action type is required',
+            });
+        }
+
+        const { AdminOrchestrator } = await import('./server/services/admin-orchestrator.service');
+        const orchestrator = new AdminOrchestrator();
+
+        let result: AdminActionData;
+
         switch (actionType) {
             case 'populateBootstrapData': {
-                const result = await orchestrator.preloadCommonData();
-                return result;
+                const populated = await orchestrator.preloadCommonData();
+
+                // Counts, not the payload. This used to return `preloadCommonData()`'s whole
+                // result -- every element plus every enhanced player, season breakdowns and
+                // all -- serialized back to the browser through the fetcher. Nothing rendered
+                // it; the section only reads `jobId` and `error`.
+                result = {
+                    success: populated.success,
+                    message:
+                        `Bootstrap populated: ${populated.results.bootstrap.teams.length} teams, ` +
+                        `${populated.results.bootstrap.events.length} gameweeks, ` +
+                        `${populated.results.bootstrap.elements.length} players, ` +
+                        `${populated.results.enhanced.length} enhanced`,
+                    data: {
+                        teams: populated.results.bootstrap.teams.length,
+                        events: populated.results.bootstrap.events.length,
+                        elements: populated.results.bootstrap.elements.length,
+                        enhanced: populated.results.enhanced.length,
+                    },
+                };
+                break;
             }
 
             case 'systemHealthCheck': {
@@ -279,11 +322,11 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
         return data<AdminActionData>(result);
     } catch (error) {
-        console.error(`❌ Admin action ${actionType} failed:`, error);
+        console.error(`❌ Admin action ${actionType ?? '(unread)'} failed:`, error);
 
         return data<AdminActionData>({
             success: false,
-            error: error instanceof Error ? error.message : 'Unknown error occurred',
+            error: describeActionFailure(error),
         });
     }
 }

--- a/draft/app/admin/components/sections/gameweek-processing-section.test.tsx
+++ b/draft/app/admin/components/sections/gameweek-processing-section.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+/* Location: app/admin/components/sections/gameweek-processing-section.test.tsx */
+
+/**
+ * This section is where an admin lands when there is no data, so it has to survive there.
+ *
+ * Two live states produce no current gameweek: an empty database, and a pre-season FPL
+ * calendar where no event carries `is_current`. Reading `.fplEvent.id` straight off the
+ * missing gameweek took the page down and hid "Populate Bootstrap Data" -- the one control
+ * that resolves the state it was crashing in.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import type { GameWeekData } from '../../../_shared/lib/fpl/fpl-types';
+import type { AdminDataContext } from '../../types/admin-orchestrator-types';
+import type { SystemStatusSummary } from '../../types/admin-types';
+import { GameweekProcessingSection } from './gameweek-processing-section';
+
+const gameweek = (id: number, deadline: string): GameWeekData =>
+    ({
+        fplEvent: { id, deadline_time: deadline, name: `Gameweek ${id}`, finished: false },
+        start: new Date(deadline),
+        end: new Date(deadline),
+    }) as unknown as GameWeekData;
+
+/** Everything the section needs in order to render at all. */
+const systemStatus = (currentGameweek: GameWeekData | undefined): SystemStatusSummary =>
+    ({
+        currentGameweek,
+        bootstrapLastUpdated: null,
+        transfers: { pending: 0, approved: 0, rejected: 0, total: 0, byDivision: {} },
+        gameweekProcessing: {
+            currentGameweek,
+            lastProcessedGameweek: 0,
+            totalGameweeks: 38,
+            processedGameweeks: [],
+            pendingGameweeks: [],
+            isUpToDate: false,
+            needsProcessing: true,
+            completionPercentage: 0,
+            lastProcessedAt: null,
+        },
+    }) as unknown as SystemStatusSummary;
+
+const sharedContext = (events: GameWeekData[]): AdminDataContext =>
+    ({ fplData: { events } }) as unknown as AdminDataContext;
+
+const renderSection = (status: SystemStatusSummary, context: AdminDataContext) => {
+    // useFetcher needs a router around it; the section never navigates.
+    const Stub = createRoutesStub([
+        {
+            path: '/admin/points',
+            Component: () => <GameweekProcessingSection systemStatus={status} sharedContext={context} />,
+        },
+    ]);
+    return render(<Stub initialEntries={['/admin/points']} />);
+};
+
+describe('GameweekProcessingSection', () => {
+    it('renders the gameweek when there is a current one', () => {
+        renderSection(systemStatus(gameweek(21, '2025-01-14T18:00:00Z')), sharedContext([]));
+
+        expect(screen.getByText('Gameweek 21')).toBeDefined();
+    });
+
+    it('renders, rather than crashing, when no gameweek is current', () => {
+        // Pre-season: a published calendar, but nothing has started.
+        const events = [gameweek(1, '2099-08-15T17:30:00Z'), gameweek(2, '2099-08-22T17:30:00Z')];
+
+        renderSection(systemStatus(undefined), sharedContext(events));
+
+        expect(screen.getByText('The season has not started yet')).toBeDefined();
+        expect(screen.getByText('None')).toBeDefined();
+    });
+
+    it('keeps Populate Bootstrap Data reachable when there is no gameweek at all', () => {
+        // An empty database -- no calendar, no current gameweek. Populating is the fix, so
+        // the button must survive the state it fixes.
+        renderSection(systemStatus(undefined), sharedContext([]));
+
+        expect(screen.getByText('The gameweek calendar has not been loaded yet')).toBeDefined();
+        expect(screen.getByRole('button', { name: /Populate Bootstrap Data/ })).toBeDefined();
+    });
+
+    it('does not offer to run a gameweek that does not exist', () => {
+        renderSection(systemStatus(undefined), sharedContext([]));
+
+        // The accessible name carries the button's ▶️ icon alongside its label.
+        const runButton = screen.getByRole('button', { name: /Run Gameweek/ });
+        expect(runButton.hasAttribute('disabled')).toBe(true);
+        expect(screen.queryByText(/Run Gameweek 0/)).toBeNull();
+    });
+
+    it('survives a shared context that carries no fpl data', () => {
+        // The admin loader returns nulls for its heavy fields on the lightweight paths.
+        renderSection(systemStatus(undefined), {} as AdminDataContext);
+
+        expect(screen.getByText('The gameweek calendar has not been loaded yet')).toBeDefined();
+    });
+});

--- a/draft/app/admin/components/sections/gameweek-processing-section.tsx
+++ b/draft/app/admin/components/sections/gameweek-processing-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useFetcher } from 'react-router';
+import { describeGameweekAvailability } from '../../../_shared/lib/gameweek-availability';
 import type { AdminDataContext } from '../../types/admin-orchestrator-types';
 import type { SystemStatusSummary } from '../../types/admin-types';
 import * as Icons from '../icons/admin-icons';
@@ -19,7 +20,7 @@ interface GameweekProcessingSectionProps {
     sharedContext: AdminDataContext;
 }
 
-export function GameweekProcessingSection({ systemStatus }: GameweekProcessingSectionProps) {
+export function GameweekProcessingSection({ systemStatus, sharedContext }: GameweekProcessingSectionProps) {
     const fetcher = useFetcher();
 
     // Progress modal state
@@ -29,14 +30,22 @@ export function GameweekProcessingSection({ systemStatus }: GameweekProcessingSe
     const isLoading = fetcher.state !== 'idle';
     const actionData = fetcher.data;
 
-    const currentGameweek = systemStatus.gameweekProcessing.currentGameweek.fplEvent.id;
+    // There is not always a current gameweek, and this section is exactly where an admin
+    // lands when there isn't -- an empty database and a pre-season FPL calendar both produce
+    // it. Reading `.fplEvent.id` straight off it crashed the page in that state, which hid
+    // the one control that fixes it.
+    const currentGameweekData = systemStatus.gameweekProcessing.currentGameweek;
+    const availability = describeGameweekAvailability(sharedContext?.fplData?.events, currentGameweekData);
+
+    const currentGameweek = currentGameweekData?.fplEvent?.id ?? 0;
     const lastProcessedGameweek = systemStatus.gameweekProcessing.lastProcessedGameweek;
-    const needsProcessing = currentGameweek > lastProcessedGameweek;
+    const needsProcessing = availability.available && currentGameweek > lastProcessedGameweek;
 
     // Check if bootstrap was run during the current gameweek
-    const currentGameweekStart = systemStatus.gameweekProcessing.currentGameweek.start;
+    const currentGameweekStart = currentGameweekData?.start;
     const bootstrapLastUpdated = systemStatus.bootstrapLastUpdated ? new Date(systemStatus.bootstrapLastUpdated) : null;
-    const bootstrapRecommended = !bootstrapLastUpdated || bootstrapLastUpdated < currentGameweekStart;
+    const bootstrapRecommended =
+        !bootstrapLastUpdated || !currentGameweekStart || bootstrapLastUpdated < new Date(currentGameweekStart);
 
     const handleCacheAction = (actionType: string) => {
         const formData = new FormData();
@@ -80,27 +89,32 @@ export function GameweekProcessingSection({ systemStatus }: GameweekProcessingSe
                 description="End-to-end gameweek workflow management"
                 actions={
                     <ActionBar align="right">
-                        {needsProcessing ? (
-                            <AdminButton
-                                variant="primary"
-                                onClick={() => handleProcessGameweek('gameweek', currentGameweek)}
-                                disabled={isLoading}
-                                loading={isLoading}
-                            >
-                                Process Gameweek {currentGameweek}
-                            </AdminButton>
+                        {availability.available ? (
+                            needsProcessing ? (
+                                <AdminButton
+                                    variant="primary"
+                                    onClick={() => handleProcessGameweek('gameweek', currentGameweek)}
+                                    disabled={isLoading}
+                                    loading={isLoading}
+                                >
+                                    Process Gameweek {currentGameweek}
+                                </AdminButton>
+                            ) : (
+                                <AdminMessage type="success">All gameweeks up to date</AdminMessage>
+                            )
                         ) : (
-                            <AdminMessage type="success">All gameweeks up to date</AdminMessage>
+                            <AdminMessage type="warning">{availability.title}</AdminMessage>
                         )}
                     </ActionBar>
                 }
             >
+                {availability.available ? null : <p>{availability.detail}</p>}
                 <AdminGrid columns="auto" minWidth="250px">
                     <StatusCard
                         icon="📅"
                         label="Current Gameweek"
-                        percentage={`Gameweek ${currentGameweek}`}
-                        status="healthy"
+                        percentage={availability.available ? `Gameweek ${currentGameweek}` : 'None'}
+                        status={availability.available ? 'healthy' : 'warning'}
                     />
                     <StatusCard
                         icon="🔄"
@@ -169,13 +183,17 @@ export function GameweekProcessingSection({ systemStatus }: GameweekProcessingSe
                     <AdminButton
                         variant="primary"
                         onClick={() => handleProcessGameweek('gameweek', currentGameweek)}
-                        disabled={isLoading}
+                        disabled={isLoading || !availability.available}
                         loading={isLoading}
                         icon={'▶️'}
                     >
-                        Run Gameweek {currentGameweek}
+                        {availability.available ? `Run Gameweek ${currentGameweek}` : 'Run Gameweek'}
                     </AdminButton>
-                    {actionData?.error && <AdminMessage type="error">Error: ${actionData.error}</AdminMessage>}
+                    {/* The `$` was literal: an admin read "Error: ${the actual message}". */}
+                    {actionData?.error && <AdminMessage type="error">Error: {actionData.error}</AdminMessage>}
+                    {actionData?.success && actionData.message && (
+                        <AdminMessage type="success">{actionData.message}</AdminMessage>
+                    )}
                 </AdminGrid>
             </AdminSection>
 


### PR DESCRIPTION
## What was happening

Clicking **Populate Bootstrap Data** on `/admin/points` showed a bare error page:

> Something went wrong on this page
> 1. Unexpected Server Error

and wrote nothing — production Firestore is still empty (`players.json` returns `[]`, verified past the CDN with `x-cache: MISS`).

That message is React Router's *production placeholder*. It substitutes it for any unhandled server error before the response leaves the function, so the real cause reached nobody: not the browser, and not the page.

## Why the cause escaped

`/admin`'s action read its form fields **outside** its own try/catch:

```ts
const formData = await requestFormData({ request, context });
const actionType = formData.get('actionType')?.trim();   // ← throws here
...
try { switch (actionType) { ... } } catch { /* reports failures */ }
```

`requestFormData` indexed the load context directly (`context[name]`). That context is `req.body` from `functions/src/ssr.ts`'s `getLoadContext`, and it is `undefined` whenever Firebase does not parse the request body — so it threw `Cannot read properties of undefined (reading 'actionType')` *before* the handler whose entire job is reporting failures could run.

`/admin` is the only one of six `requestFormData` callers exposed this way. The other five (`draft`, `cup-submit`, `cup-admin`, `transfers`, `api.gw-points`) already call it inside a try.

## Changes

- **`requestFormData`** tolerates an absent context and an unreadable body, and no longer claims to return a `URLSearchParams` it never returned.
- **`/admin`'s action** parses the form inside the try, and reports the whole cause chain via the existing `toErrorChain` rather than just `error.message` — for a wrapped failure the outermost message is the least useful link (`SHEET_READ_ERROR` says a read gave up; the 403 beneath it says why).
- **The gameweek section survives having no current gameweek.** An empty database and a pre-season FPL calendar both produce that state, and dereferencing `.fplEvent.id` there crashed the page — hiding the populate button that fixes the state it was crashing in. Wording reuses the already-tested `describeGameweekAvailability`.
- **`populateBootstrapData` returns counts, not its payload.** It was serializing every element plus every enhanced player with full season breakdowns back to the browser through the fetcher: **574,845 bytes → 224**, measured. Nothing rendered it; the section only reads `jobId` and `error`.
- **The error banner interpolated a literal `$`**, so an admin read `Error: ${the actual message}` — in exactly the place the new error text appears.

## What this does not do

It does not prove the populate now succeeds in production. It makes the next attempt **say why** if it does not. Retry the populate once this is deployed.

## Diagnosis notes (so nobody repeats them)

Ruled out with a read-only probe against live Sheets and FPL:

| measurement | live value | verdict |
|---|---|---|
| `Players` sheet rows | 558 | healthy |
| FPL bootstrap elements | 564 | healthy |
| matched by code | **558 of 558** | not the "no players in both FPL and sheets" throw |
| element-summary fetch | 10 in 0.1s → ~3s projected for 558 | **not** the 60s function timeout |

The fixture harness runs the identical action end to end without error, which is what established this was environment rather than logic.

One finding worth carrying into Part E1: **the live FPL API is in 2026/27 pre-season** — 38 events, 0 finished, no `is_current` at all. The fixtures cannot reproduce that, because the captured 2024/25 bootstrap is a finished season whose frozen `is_current` always rescues the fallback in `getCurrentGameweekData()`. The plan's `preseason` scenario (2024-08-01) yields a current GW1, so it does **not** cover "no current gameweek anywhere".

## Testing

- `draft/app/_shared/lib/form-data.test.ts` — 7 tests over the shapes the load context actually arrives in. **5 of them fail on the pre-fix code** with `Cannot read properties of undefined (reading 'actionType')`, which is the exact throw production was sanitizing.
- `draft/app/admin/components/sections/gameweek-processing-section.test.tsx` — 5 render tests, including that the populate button stays reachable when there is no gameweek data at all.

`yarn test` 536 passing / 54 files (was 524 / 52) · `yarn ratchet` all four counts unchanged at baseline · `yarn build` clean, so the `functions` workspace type-checks.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)