### PR TITLE
fix: make the admin actions actually work in production

### DIFF
--- a/draft/app/_shared/lib/firestore-cache/clear-service.ts
+++ b/draft/app/_shared/lib/firestore-cache/clear-service.ts
@@ -12,13 +12,129 @@ interface ClearProgress {
     error?: string;
 }
 
+/** What one bounded pass of `clearEverything` managed to do. */
+export interface ClearPass {
+    /** Documents deleted in this pass. */
+    deleted: number;
+    /** Per collection, what this pass removed and whether anything is left. */
+    collections: Array<{ name: string; deleted: number; emptied: boolean }>;
+    /** False when the budget ran out with documents still to delete — call again. */
+    done: boolean;
+}
+
 export class FirestoreClearService {
     private client: FirestoreClient;
-    private readonly BATCH_SIZE = 10; // Documents per batch
-    private readonly DELAY_BETWEEN_BATCHES = 100; // ms
+    /**
+     * Firestore's hard limit is 500 writes per batch. This was 10, with a 100ms sleep
+     * between batches, which made clearing a few thousand documents take minutes — long
+     * enough that the ssr function's 60s timeout killed "Reset Database" every time and
+     * returned a generic error with nothing in it.
+     */
+    private readonly BATCH_SIZE = 400;
+    private readonly DELAY_BETWEEN_BATCHES = 0; // ms; batches of 400 are their own rate limit
+
+    /**
+     * How long one `clearEverything` pass may run for.
+     *
+     * The ssr function's timeout is 60s, so a pass stops well inside it and reports what is
+     * left. The caller repeats until `done`, which is what makes a collection of any size
+     * clearable through a request that cannot itself run for long.
+     */
+    private readonly PASS_BUDGET_MS = 25_000;
 
     constructor() {
         this.client = new FirestoreClient();
+    }
+
+    /**
+     * Delete everything, a bounded pass at a time.
+     *
+     * Two things were wrong with clearing a fixed list of collections in one request:
+     * `player-gameweeks` and `player_stats_cache` are left over from an earlier version of
+     * the app and appear nowhere in the code, so no hard-coded list mentioned them and every
+     * "reset the entire database" left them untouched; and a collection large enough to
+     * outlast the function timeout could never be cleared at all.
+     *
+     * So the collections are discovered from Firestore rather than listed here, and a pass
+     * stops when its time budget runs out and says whether to call it again.
+     */
+    async clearEverything(budgetMs: number = this.PASS_BUDGET_MS): Promise<ClearPass> {
+        const startedAt = Date.now();
+        const names = await this.listCollectionNames();
+        const collections: ClearPass['collections'] = [];
+        let deleted = 0;
+        let done = true;
+
+        for (const name of names) {
+            const remainingBudget = budgetMs - (Date.now() - startedAt);
+            if (remainingBudget <= 0) {
+                // Untouched this pass. Not emptied, so the caller comes back.
+                done = false;
+                break;
+            }
+
+            const pass = await this.clearCollectionWithin(name, remainingBudget);
+            deleted += pass.deleted;
+            collections.push({ name, deleted: pass.deleted, emptied: pass.emptied });
+            if (!pass.emptied) done = false;
+        }
+
+        console.log(`🗑️ Clear pass: ${deleted} documents in ${Date.now() - startedAt}ms, done=${done}`);
+
+        return { deleted, collections, done };
+    }
+
+    /**
+     * Delete from one collection until it is empty or the budget runs out.
+     *
+     * Reads a bounded page rather than every id up front: `getAllDocumentIds` pulls the whole
+     * collection into memory, which is its own failure mode on a large one.
+     */
+    private async clearCollectionWithin(
+        collectionName: string,
+        budgetMs: number,
+    ): Promise<{ deleted: number; emptied: boolean }> {
+        const startedAt = Date.now();
+        const db = this.client.db;
+        let deleted = 0;
+
+        while (Date.now() - startedAt < budgetMs) {
+            const snapshot = await db.collection(collectionName).select().limit(this.BATCH_SIZE).get();
+            if (snapshot.docs.length === 0) {
+                return { deleted, emptied: true };
+            }
+
+            const batch = db.batch();
+            snapshot.docs.forEach((doc) => batch.delete(doc.ref));
+            await batch.commit();
+
+            deleted += snapshot.docs.length;
+            if (this.DELAY_BETWEEN_BATCHES > 0) await this.delay(this.DELAY_BETWEEN_BATCHES);
+        }
+
+        // Budget spent. A shorter page than a full batch means it was the last one anyway.
+        return { deleted, emptied: false };
+    }
+
+    /**
+     * Every collection in the database, falling back to the ones the app knows about.
+     *
+     * `listCollections()` needs `datastore.entities.list`, which a restricted service account
+     * may not have. Falling back keeps reset working at the level it worked at before rather
+     * than failing outright — but it will then miss orphaned collections, so it says so.
+     */
+    private async listCollectionNames(): Promise<string[]> {
+        try {
+            const collections = await this.client.db.listCollections();
+            return collections.map((collection) => collection.id).sort();
+        } catch (error) {
+            console.warn(
+                '⚠️ Could not list collections; falling back to the known list. Collections this build ' +
+                    'does not name will not be cleared.',
+                error,
+            );
+            return Object.values(this.client.collections);
+        }
     }
 
     /**

--- a/draft/app/_shared/lib/firestore-cache/firestore-memory.test.ts
+++ b/draft/app/_shared/lib/firestore-cache/firestore-memory.test.ts
@@ -197,4 +197,75 @@ describe('the fixture Firestore, through FirestoreClearService', () => {
         const snapshot = await getFirestoreInstance().collection(CACHE_STATE).count().get();
         expect(snapshot.data().count).toBe(0);
     });
+
+    /**
+     * These cover the two things that made "Reset Database" fail in production: a
+     * hard-coded collection list that had gone stale, and a single request that could not
+     * outlive the function timeout.
+     */
+    describe('clearEverything', () => {
+        const countIn = async (name: string) =>
+            (await getFirestoreInstance().collection(name).count().get()).data().count;
+
+        it('clears collections this build does not know about', async () => {
+            // The real orphans: left by an earlier version, named nowhere in the code, and
+            // therefore untouched by every reset that walked a hard-coded list.
+            await client.setDocument('player-gameweeks', 'gw1', cacheDoc('orphan'));
+            await client.setDocument('player_stats_cache', '123', cacheDoc('orphan'));
+            await client.setDocument(CACHE_STATE, 'events', cacheDoc('known'));
+
+            const pass = await new FirestoreClearService().clearEverything();
+
+            expect(pass.done).toBe(true);
+            expect(await countIn('player-gameweeks')).toBe(0);
+            expect(await countIn('player_stats_cache')).toBe(0);
+            expect(await countIn(CACHE_STATE)).toBe(0);
+        });
+
+        it('reports what it deleted, per collection', async () => {
+            await client.setDocument('player-gameweeks', 'gw1', cacheDoc(1));
+            await client.setDocument('player-gameweeks', 'gw2', cacheDoc(2));
+
+            const pass = await new FirestoreClearService().clearEverything();
+
+            expect(pass.deleted).toBe(2);
+            expect(pass.collections).toContainEqual({ name: 'player-gameweeks', deleted: 2, emptied: true });
+        });
+
+        it('says it is done when there was nothing to delete', async () => {
+            const pass = await new FirestoreClearService().clearEverything();
+
+            expect(pass).toEqual({ deleted: 0, collections: [], done: true });
+        });
+
+        it('stops when its time budget runs out and reports that more remains', async () => {
+            for (let i = 0; i < 25; i++) {
+                await client.setDocument(CACHE_STATE, `doc-${i}`, cacheDoc(i));
+            }
+
+            // A zero budget cannot complete a pass, which is the shape of the real failure:
+            // the caller must be told to come back rather than being left to assume success.
+            const pass = await new FirestoreClearService().clearEverything(0);
+
+            expect(pass.done).toBe(false);
+            expect(await countIn(CACHE_STATE)).toBe(25);
+        });
+
+        it('finishes a large collection across repeated passes', async () => {
+            for (let i = 0; i < 30; i++) {
+                await client.setDocument(CACHE_STATE, `doc-${i}`, cacheDoc(i));
+            }
+
+            const service = new FirestoreClearService();
+            let passes = 0;
+            let pass = await service.clearEverything();
+            while (!pass.done && passes < 10) {
+                pass = await service.clearEverything();
+                passes++;
+            }
+
+            expect(pass.done).toBe(true);
+            expect(await countIn(CACHE_STATE)).toBe(0);
+        });
+    });
 });

--- a/draft/app/_shared/lib/firestore-cache/firestore-memory.ts
+++ b/draft/app/_shared/lib/firestore-cache/firestore-memory.ts
@@ -18,6 +18,7 @@
  *   collection(n).select().get()          -- clear-service.ts, ids only
  *   collection(n).count().get()           -- fpl-firestore.ts
  *   collection(n).limit(1).get()          -- system-status.service.ts
+ *   db.listCollections()                  -- clear-service.ts, so reset finds every one
  *   collection(n).where(f, op, v).get()   -- firestore-client.ts
  *   db.getAll(...refs)                    -- firestore-client.ts
  *   db.batch().set() / .update() / .delete() / .commit()
@@ -176,6 +177,20 @@ class MemoryStore {
      */
     ids(name: string): string[] {
         return [...this.collection(name).keys()].sort();
+    }
+
+    /**
+     * Names of collections that actually hold documents.
+     *
+     * Empty ones are filtered out because `collection(name)` creates on read, so a single
+     * lookup for a collection that does not exist would otherwise invent it -- and because
+     * real Firestore's `listCollections()` only returns collections with documents in them.
+     */
+    collectionNames(): string[] {
+        return [...this.collections.entries()]
+            .filter(([, docs]) => docs.size > 0)
+            .map(([name]) => name)
+            .sort();
     }
 
     clear(): void {
@@ -359,6 +374,11 @@ class MemoryDocumentReference {
 }
 
 class MemoryCollectionReference extends MemoryQuery {
+    /** Firestore calls the collection's name `id` on a reference; `listCollections()` reads it. */
+    get id(): string {
+        return this.collectionName;
+    }
+
     doc(id: string): MemoryDocumentReference {
         return new MemoryDocumentReference(this.store, this.collectionName, id);
     }
@@ -399,6 +419,17 @@ class MemoryFirestore {
 
     async getAll(...refs: MemoryDocumentReference[]): Promise<MemoryDocumentSnapshot[]> {
         return Promise.all(refs.map((ref) => ref.get()));
+    }
+
+    /**
+     * Every collection holding documents, as the real API's `listCollections()` does.
+     *
+     * Reset needs this because a hard-coded list of collections goes stale silently: two
+     * collections from an earlier version of the app survived every "reset the entire
+     * database" simply because nothing in the code named them any more.
+     */
+    async listCollections(): Promise<MemoryCollectionReference[]> {
+        return this.store.collectionNames().map((name) => this.collection(name));
     }
 
     batch(): MemoryWriteBatch {

--- a/draft/app/admin/admin-transfers.route.tsx
+++ b/draft/app/admin/admin-transfers.route.tsx
@@ -27,6 +27,13 @@ export default function AdminTransfersRoute() {
     const { sharedContext, systemStatus, transfersData, teamsByCode } = useOutletContext<AdminOutletContext>();
     const [searchParams] = useSearchParams();
 
+    // The loader throws a friendly "no current gameweek" response before this ever renders,
+    // so this is belt and braces -- but it is what lets the type stay honest about the
+    // gameweek being optional rather than fabricating one.
+    if (!systemStatus.currentGameweek) {
+        return <p>There is no current gameweek, so there are no transfers to review.</p>;
+    }
+
     // Get filter parameters from URL
     const selectedDivisionId = searchParams.get('division') || sharedContext.sheetData.divisions[0]?.id;
     const selectedGameweekId =

--- a/draft/app/admin/admin.route.tsx
+++ b/draft/app/admin/admin.route.tsx
@@ -14,7 +14,7 @@ import { requestFormData } from '../_shared/lib/form-data';
 import type { FplTeam } from '../_shared/lib/fpl/fpl-types';
 import { describeGameweekAvailability } from '../_shared/lib/gameweek-availability';
 import { describeUnknownDivisions } from '../_shared/lib/league-divisions';
-import { friendlyErrorResponse, toErrorChain } from '../_shared/lib/loader-error';
+import { friendlyErrorResponse, loaderErrorResponse, toErrorChain } from '../_shared/lib/loader-error';
 import type { DivisionId } from '../_shared/types/league-types';
 import type { DraftAction } from '../draft';
 import type { TransferAdminOverviewData } from '../transfers';
@@ -60,56 +60,71 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     console.log('🔄 Loading admin dashboard data...');
 
-    const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
-    const { AdminOrchestrator } = await import('./server/services/admin-orchestrator.service');
-    const orchestrator = new AdminOrchestrator();
-    const teamsByCode = await fplApiCache.getTeamsByCode();
+    // Sheets, FPL and Firestore are all read below and any of them can fail. Unwrapped, that
+    // reached the browser as the same opaque "Unexpected Server Error" the populate action
+    // used to give -- on the one page whose job is diagnosing exactly those systems.
+    try {
+        const { fplApiCache } = await import('../_shared/lib/fpl/api-cache');
+        const { AdminOrchestrator } = await import('./server/services/admin-orchestrator.service');
+        const orchestrator = new AdminOrchestrator();
+        const teamsByCode = await fplApiCache.getTeamsByCode();
 
-    const [systemStatus, sharedContext] = await Promise.all([
-        orchestrator.getSystemStatus(),
-        orchestrator.getSharedContext(),
-    ]);
+        const [systemStatus, sharedContext] = await Promise.all([
+            orchestrator.getSystemStatus(),
+            orchestrator.getSharedContext(),
+        ]);
 
-    // Load transfer-specific data only on the transfers admin page (heavy validation)
-    let transfersData: Record<string, TransferAdminOverviewData> | null = null;
+        // Load transfer-specific data only on the transfers admin page (heavy validation)
+        let transfersData: Record<string, TransferAdminOverviewData> | null = null;
 
-    const isTransferRoute = url.pathname.includes('/admin/transfers');
+        const isTransferRoute = url.pathname.includes('/admin/transfers');
 
-    if (isTransferRoute) {
-        // Transfer admin is gameweek-scoped, so with no current gameweek there is nothing
-        // to approve. Explained rather than crashed on -- the rest of /admin still loads,
-        // which is what you need in order to go and populate the data.
-        const availability = describeGameweekAvailability(sharedContext.fplData.events, systemStatus.currentGameweek);
-        if (!availability.available) {
-            throw friendlyErrorResponse(availability.title, availability.detail);
+        if (isTransferRoute) {
+            // Transfer admin is gameweek-scoped, so with no current gameweek there is nothing
+            // to approve. Explained rather than crashed on -- the rest of /admin still loads,
+            // which is what you need in order to go and populate the data.
+            const availability = describeGameweekAvailability(
+                sharedContext.fplData.events,
+                systemStatus.currentGameweek,
+            );
+            if (!availability.available) {
+                throw friendlyErrorResponse(availability.title, availability.detail);
+            }
+
+            const { getTransfersAdminData } = await import('./server/transfers-admin.server');
+            const divisions = sharedContext.sheetData.divisions;
+            // `availability.gameweek` rather than `systemStatus.currentGameweek`: same value,
+            // but the narrowed one is the one the guard above proved is there.
+            const selectedGameweekId =
+                Number.parseInt(url.searchParams.get('gameweek') || '', 10) || availability.gameweek.fplEvent.id;
+            const gameweek = sharedContext.fplData.events.find((gw) => gw.fplEvent.id === selectedGameweekId);
+
+            transfersData = await getTransfersAdminData(divisions, gameweek);
         }
 
-        const { getTransfersAdminData } = await import('./server/transfers-admin.server');
-        const divisions = sharedContext.sheetData.divisions;
-        const selectedGameweekId =
-            Number.parseInt(url.searchParams.get('gameweek') || '', 10) || systemStatus.currentGameweek.fplEvent.id;
-        const gameweek = sharedContext.fplData.events.find((gw) => gw.fplEvent.id === selectedGameweekId);
+        // A division in the sheet that this build does not know about is worth saying out loud
+        // rather than silently dropping. It used to announce itself as
+        // "Cannot read properties of undefined (reading 'push')".
+        const unknownDivisions = describeUnknownDivisions(
+            (sharedContext.sheetData.divisions ?? []).map((division: { id?: string }) => division.id),
+        );
+        if (unknownDivisions) console.warn(`⚠️  ${unknownDivisions}`);
 
-        transfersData = await getTransfersAdminData(divisions, gameweek);
+        return {
+            systemStatus,
+            sharedContext,
+            transfersData,
+            teamsByCode,
+            unknownDivisions,
+            cacheStats: null,
+            loadedAt: new Date().toISOString(),
+        };
+    } catch (error) {
+        // The friendly "no gameweek" state above is a deliberate result, not a failure.
+        if (error instanceof Response) throw error;
+
+        throw loaderErrorResponse('Failed to load the admin dashboard', error);
     }
-
-    // A division in the sheet that this build does not know about is worth saying out loud
-    // rather than silently dropping. It used to announce itself as
-    // "Cannot read properties of undefined (reading 'push')".
-    const unknownDivisions = describeUnknownDivisions(
-        (sharedContext.sheetData.divisions ?? []).map((division: { id?: string }) => division.id),
-    );
-    if (unknownDivisions) console.warn(`⚠️  ${unknownDivisions}`);
-
-    return {
-        systemStatus,
-        sharedContext,
-        transfersData,
-        teamsByCode,
-        unknownDivisions,
-        cacheStats: null,
-        loadedAt: new Date().toISOString(),
-    };
 }
 
 /**
@@ -210,8 +225,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
                 // Add a small delay to let the SSE connection establish first
                 setTimeout(() => {
                     regeneratePoints(jobId, jobType, orchestrator, gameweek || undefined).catch((error) => {
-                        console.error('🚨 Background job error:', error);
-                        throw new Error('🚨 Background job error:', error.message);
+                        // Log only. Rethrowing from a setTimeout callback reaches no caller --
+                        // it becomes an unhandled rejection, which on Node takes the process
+                        // down. And `new Error(msg, string)` was wrong regardless: the second
+                        // argument is an options object, so that `error.message` was dropped
+                        // on the floor. `regeneratePoints` has already recorded the failure on
+                        // the job itself, which is what the client polls and the admin sees.
+                        console.error(`🚨 Background job ${jobId} failed:`, error);
                     });
                 }, 100); // 100ms delay
 

--- a/draft/app/admin/admin.route.tsx
+++ b/draft/app/admin/admin.route.tsx
@@ -258,8 +258,19 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
             // Cache management actions using the unified cache API
             case 'resetDatabase': {
-                await orchestrator.clearAllData();
-                result = { success: true, message: 'Database reset completed' };
+                // One bounded pass. A collection too large to clear inside the function's
+                // 60s timeout used to kill the request outright, so the client repeats this
+                // until `done` rather than asking for the whole thing at once.
+                const pass = await orchestrator.clearAllData();
+                const summary = pass.collections.map(({ name, deleted }) => `${name} ${deleted}`).join(', ');
+
+                result = {
+                    success: true,
+                    message: pass.done
+                        ? `Database reset completed — ${pass.deleted} documents deleted${summary ? ` (${summary})` : ''}`
+                        : `Deleted ${pass.deleted} documents${summary ? ` (${summary})` : ''} — more remain, continuing…`,
+                    data: pass,
+                };
                 break;
             }
             case 'refreshSheetsData': {

--- a/draft/app/admin/components/sections/cache-management-section.tsx
+++ b/draft/app/admin/components/sections/cache-management-section.tsx
@@ -1,5 +1,6 @@
 /* Location: app/admin/components/sections/cache-management-section.tsx */
 
+import { useEffect, useRef } from 'react';
 import { useFetcher } from 'react-router';
 import type { AdminDataContext } from '../../types/admin-orchestrator-types';
 import type { SystemStatusSummary } from '../../types/admin-types';
@@ -17,8 +18,12 @@ interface CacheManagementSectionProps {
     cacheStats?: any;
 }
 
+/** Guards against a bug in the clear loop turning into an unbounded stream of deletes. */
+const MAX_RESET_PASSES = 200;
+
 export function CacheManagementSection({ systemStatus, sharedContext }: CacheManagementSectionProps) {
     const fetcher = useFetcher();
+    const resetPasses = useRef(0);
 
     const isLoading = fetcher.state !== 'idle';
     const actionData = fetcher.data;
@@ -26,6 +31,8 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
     const cacheStatus = sharedContext.cacheStatus;
 
     const handleCacheAction = (actionType: string) => {
+        if (actionType === 'resetDatabase') resetPasses.current = 0;
+
         const formData = new FormData();
         formData.append('actionType', actionType);
 
@@ -35,6 +42,30 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
             action: '/admin', // This ensures we hit the parent route's action
         });
     };
+
+    /**
+     * Reset clears as much as it can inside the function's timeout and says whether more is
+     * left. Collections large enough to outlast a single request -- which is what killed
+     * "Reset Database" outright -- are cleared by coming back for another pass.
+     */
+    const resetPass = actionData?.data as { done?: boolean; deleted?: number } | undefined;
+    const resetIncomplete = fetcher.state === 'idle' && resetPass?.done === false;
+
+    // Between passes the fetcher is briefly idle; the reset is still running.
+    const busy = isLoading || resetIncomplete;
+
+    useEffect(() => {
+        if (!resetIncomplete) return;
+        if (resetPasses.current >= MAX_RESET_PASSES) {
+            console.error('Reset stopped after', MAX_RESET_PASSES, 'passes without finishing.');
+            return;
+        }
+
+        resetPasses.current += 1;
+        const formData = new FormData();
+        formData.append('actionType', 'resetDatabase');
+        fetcher.submit(formData, { method: 'POST', action: '/admin' });
+    }, [resetIncomplete, fetcher]);
 
     return (
         <AdminContainer>
@@ -50,14 +81,14 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                         <AdminButton
                             variant="secondary"
                             onClick={() => handleCacheAction('refreshFplData')}
-                            disabled={isLoading}
+                            disabled={busy}
                         >
                             Refresh FPL Data
                         </AdminButton>
                         <AdminButton
                             variant="secondary"
                             onClick={() => handleCacheAction('refreshSheetsData')}
-                            disabled={isLoading}
+                            disabled={busy}
                         >
                             Refresh Sheets Data
                         </AdminButton>
@@ -68,7 +99,7 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                         <AdminButton
                             variant="danger"
                             onClick={() => handleCacheAction('invalidateAllCaches')}
-                            disabled={isLoading}
+                            disabled={busy}
                             requireConfirm={true}
                             confirmMessage="This will invalidate ALL caches system-wide. Are you sure?"
                         >
@@ -77,7 +108,7 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                         <AdminButton
                             variant="danger"
                             onClick={() => handleCacheAction('resetDatabase')}
-                            disabled={isLoading}
+                            disabled={busy}
                             requireConfirm={true}
                             confirmMessage="This will RESET the entire database. This cannot be undone. Are you absolutely sure?"
                         >
@@ -105,7 +136,7 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                     variant="secondary"
                     className={`${styles.actionButton} ${styles.secondary}`}
                     onClick={() => window.open('/api/cache?action=status', '_blank')}
-                    disabled={isLoading}
+                    disabled={busy}
                 >
                     <Icons.FileIcon />
                     View Cache Statistics
@@ -115,7 +146,7 @@ export function CacheManagementSection({ systemStatus, sharedContext }: CacheMan
                     variant="secondary"
                     className={`${styles.actionButton} ${styles.secondary}`}
                     onClick={() => window.open('/api/cache?action=keys', '_blank')}
-                    disabled={isLoading}
+                    disabled={busy}
                 >
                     <Icons.DatabaseIcon />
                     View All Cache Keys

--- a/draft/app/admin/components/sections/overview-section.test.tsx
+++ b/draft/app/admin/components/sections/overview-section.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+/* Location: app/admin/components/sections/overview-section.test.tsx */
+
+/**
+ * The overview is the first page an admin opens, including when nothing is set up.
+ *
+ * It used to be handed a fabricated `{ fplEvent: { id: 1 } }` whenever the status services
+ * failed, so it cheerfully reported "GW 1 needs processing" for a league with no gameweeks,
+ * no calendar and no players. That is worse than a crash: it sends someone looking for a
+ * processing problem instead of an empty database.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import type { GameWeekData } from '../../../_shared/lib/fpl/fpl-types';
+import type { SystemStatusSummary } from '../../types/admin-types';
+import { OverviewSection } from './overview-section';
+
+const gameweek = (id: number): GameWeekData =>
+    ({ fplEvent: { id, name: `Gameweek ${id}` }, start: new Date(), end: new Date() }) as unknown as GameWeekData;
+
+const systemStatus = (currentGameweek: GameWeekData | undefined, lastProcessedGameweek = 0): SystemStatusSummary =>
+    ({
+        currentGameweek,
+        bootstrapLastUpdated: null,
+        systemHealth: {
+            fplCache: { status: 'healthy' },
+            firebase: { status: 'healthy', message: '' },
+            googleSheets: { status: 'healthy', message: '' },
+            overall: { status: 'healthy', message: 'All systems operational' },
+        },
+        transfers: { pending: 0, approved: 0, rejected: 0, total: 0, byDivision: {} },
+        draft: { stage: 'complete', isComplete: true },
+        gameweekProcessing: { currentGameweek, lastProcessedGameweek },
+        recommendations: [],
+    }) as unknown as SystemStatusSummary;
+
+const renderOverview = (status: SystemStatusSummary) => {
+    const Stub = createRoutesStub([
+        {
+            path: '/admin',
+            Component: () => (
+                <OverviewSection
+                    systemStatus={status}
+                    sharedContext={{} as never}
+                    expandedSections={new Set()}
+                    toggleSection={() => undefined}
+                />
+            ),
+        },
+    ]);
+    return render(<Stub initialEntries={['/admin']} />);
+};
+
+describe('OverviewSection', () => {
+    it('reports the gameweek as processed when it matches the last processed one', () => {
+        renderOverview(systemStatus(gameweek(21), 21));
+
+        expect(screen.getByText('GW 21 processed')).toBeDefined();
+    });
+
+    it('reports the gameweek as needing processing when it does not', () => {
+        renderOverview(systemStatus(gameweek(21), 20));
+
+        expect(screen.getByText('GW 21 needs processing')).toBeDefined();
+    });
+
+    it('says there is no current gameweek rather than inventing gameweek 1', () => {
+        // The regression. An empty database produced "GW 1 needs processing".
+        renderOverview(systemStatus(undefined));
+
+        expect(screen.getByText('No current gameweek')).toBeDefined();
+        expect(screen.queryByText(/GW 1/)).toBeNull();
+    });
+
+    it('does not offer to copy player stats when there is no gameweek to copy them for', () => {
+        renderOverview(systemStatus(undefined));
+
+        expect(screen.queryByRole('button', { name: /copy/i })).toBeNull();
+    });
+});

--- a/draft/app/admin/components/sections/overview-section.tsx
+++ b/draft/app/admin/components/sections/overview-section.tsx
@@ -36,6 +36,12 @@ export function OverviewSection({ systemStatus }: OverviewSectionProps) {
     const fetcher = useFetcher();
     const actionData = fetcher.data;
 
+    // Absent before anything has been populated, and in pre-season. The overview is the first
+    // page an admin opens in exactly that state, so it has to say so rather than crash.
+    const currentGameweekId = systemStatus.currentGameweek?.fplEvent.id;
+    const isProcessed =
+        currentGameweekId !== undefined && systemStatus.gameweekProcessing.lastProcessedGameweek === currentGameweekId;
+
     return (
         <AdminContainer>
             {/* System Health Overview */}
@@ -77,17 +83,13 @@ export function OverviewSection({ systemStatus }: OverviewSectionProps) {
                         icon="📊"
                         label="Gameweek Processing"
                         percentage={
-                            systemStatus.gameweekProcessing.lastProcessedGameweek ===
-                            systemStatus.currentGameweek.fplEvent.id
-                                ? `GW ${systemStatus.currentGameweek.fplEvent.id} processed`
-                                : `GW ${systemStatus.currentGameweek.fplEvent.id} needs processing`
+                            currentGameweekId === undefined
+                                ? 'No current gameweek'
+                                : isProcessed
+                                  ? `GW ${currentGameweekId} processed`
+                                  : `GW ${currentGameweekId} needs processing`
                         }
-                        status={
-                            systemStatus.gameweekProcessing.lastProcessedGameweek ===
-                            systemStatus.currentGameweek.fplEvent.id
-                                ? 'healthy'
-                                : 'warning'
-                        }
+                        status={isProcessed ? 'healthy' : 'warning'}
                     />
                 </AdminGrid>
             </AdminSection>
@@ -106,7 +108,8 @@ export function OverviewSection({ systemStatus }: OverviewSectionProps) {
                 </ul>
             </AdminSection>
 
-            <CopyPlayerStats currentGameweekId={systemStatus.currentGameweek.fplEvent.id} />
+            {/* Nothing to copy stats for until there is a gameweek. */}
+            {currentGameweekId !== undefined && <CopyPlayerStats currentGameweekId={currentGameweekId} />}
 
             {/* Action Messages */}
             {actionData?.success && actionData.message && (

--- a/draft/app/admin/components/sections/transfers-section.tsx
+++ b/draft/app/admin/components/sections/transfers-section.tsx
@@ -457,7 +457,16 @@ export function TransfersSection({
     const divisionTransferData = transfersData[selectedDivision.id];
     const navigate = useNavigate();
 
-    const availableGameweeks = Array.from({ length: systemStatus.currentGameweek.fplEvent.id }, (_, i) => i + 1);
+    // Transfers are gameweek-scoped, so without one there is nothing here. The loader throws
+    // a friendly response before this renders; this keeps the narrowing local and honest
+    // rather than asserting a gameweek the type no longer promises. After all hooks, so the
+    // early return cannot change hook order.
+    const currentGameweekData = systemStatus.currentGameweek;
+    if (!currentGameweekData) {
+        return <p>There is no current gameweek, so there are no transfers to review.</p>;
+    }
+
+    const availableGameweeks = Array.from({ length: currentGameweekData.fplEvent.id }, (_, i) => i + 1);
     const selectedDivisionData = transfersData?.[selectedDivision.id];
     const handleDivisionChange = (divisionId: string) => {
         if (divisionId !== 'all') {
@@ -491,7 +500,7 @@ export function TransfersSection({
                 actions={
                     <ActionBar align={'right'} gap={'md'}>
                         <GameweekSelector
-                            currentGameweekData={systemStatus.currentGameweek}
+                            currentGameweekData={currentGameweekData}
                             selectedGameweekData={selectedGameweek}
                             availableGameweeks={availableGameweeks}
                         />

--- a/draft/app/admin/server/services/admin-orchestrator.service.ts
+++ b/draft/app/admin/server/services/admin-orchestrator.service.ts
@@ -215,7 +215,8 @@ export class AdminOrchestrator {
         return result;
     }
 
+    /** One bounded pass of the reset. Repeat until the result says `done`. */
     public async clearAllData() {
-        return await clearService.clearAllData();
+        return await clearService.clearEverything();
     }
 }

--- a/draft/app/admin/server/services/system-status.service.ts
+++ b/draft/app/admin/server/services/system-status.service.ts
@@ -2,7 +2,6 @@
 
 import { getFirestoreInstance } from '../../../_shared/lib/firestore-cache/firebase.admin';
 import { fplApiCache } from '../../../_shared/lib/fpl/api-cache';
-import type { GameWeekData } from '../../../_shared/lib/fpl/fpl-types';
 import { groupByDivision } from '../../../_shared/lib/group-by-id';
 import { readDivisions } from '../../../_shared/lib/sheets/divisions';
 import { readUserTeams } from '../../../_shared/lib/sheets/user-teams';
@@ -87,7 +86,11 @@ export async function getSystemStatus(): Promise<SystemStatusSummary> {
         };
 
         console.log(
-            `✅ System Status Summary: GW${gameweekProcessingStatus.currentGameweek.fplEvent.id}, ${overallHealth.status.toUpperCase()}, ${recommendations.length} recommendations`,
+            `✅ System Status Summary: ${
+                gameweekProcessingStatus.currentGameweek
+                    ? `GW${gameweekProcessingStatus.currentGameweek.fplEvent.id}`
+                    : 'no current gameweek'
+            }, ${overallHealth.status.toUpperCase()}, ${recommendations.length} recommendations`,
         );
 
         return summary;
@@ -96,7 +99,9 @@ export async function getSystemStatus(): Promise<SystemStatusSummary> {
 
         // Return safe defaults on error
         return {
-            currentGameweek: { fplEvent: { id: 1 } } as GameWeekData,
+            // No fabricated gameweek. Reporting "Gameweek 1" for a league that has none sent
+            // admins looking for a processing problem instead of an empty database.
+            currentGameweek: undefined,
             bootstrapLastUpdated: null,
             systemHealth: {
                 fplCache: FPL_CACHE_HEALTH_UNKNOWN,
@@ -107,7 +112,7 @@ export async function getSystemStatus(): Promise<SystemStatusSummary> {
             transfers: { pending: 0, approved: 0, rejected: 0, total: 0, byDivision: {} },
             draft: DRAFT_STATUS_UNKNOWN,
             gameweekProcessing: {
-                currentGameweek: { fplEvent: { id: 1 } } as GameWeekData,
+                currentGameweek: undefined,
                 lastProcessedGameweek: 0,
                 totalGameweeks: 38,
                 processedGameweeks: [],
@@ -330,7 +335,10 @@ async function getGameweekProcessingStatusReal() {
         const pointsService = new GameweekPointsService(); // todo: pass in context
         const pointsStatus = await pointsService.getPointsStatus();
 
-        const currentGameweekId = pointsStatus.currentGameweek.fplEvent.id;
+        // No current gameweek is a state, not a failure. This used to throw here and be
+        // caught below, which reported the whole gameweek status as broken -- and then
+        // invented "Gameweek 1" to replace it.
+        const currentGameweekId = pointsStatus.currentGameweek?.fplEvent.id ?? 0;
         const lastProcessedGameweek = pointsStatus.lastGameweek;
 
         // Calculate processed and pending gameweeks
@@ -362,7 +370,7 @@ async function getGameweekProcessingStatusReal() {
     } catch (error) {
         console.error('Failed to load gameweek processing status:', error);
         return {
-            currentGameweek: { fplEvent: { id: 1 } } as GameWeekData,
+            currentGameweek: undefined,
             lastProcessedGameweek: 0,
             totalGameweeks: 38,
             processedGameweeks: [],

--- a/draft/app/admin/types/admin-types.ts
+++ b/draft/app/admin/types/admin-types.ts
@@ -142,7 +142,13 @@ export interface FplCacheHealth {
 }
 
 export interface SystemStatusSummary {
-    currentGameweek: GameWeekData;
+    /**
+     * Absent when nothing is current — an empty database, or a pre-season calendar where no
+     * event carries `is_current`. Optional because the alternative was worse: the status
+     * services used to substitute a fabricated `{ fplEvent: { id: 1 } }` whenever they
+     * failed, so `/admin` reported "Gameweek 1" for a league that had no gameweeks at all.
+     */
+    currentGameweek: GameWeekData | undefined;
     bootstrapLastUpdated: string | null;
     systemHealth: {
         fplCache: FplCacheHealth;
@@ -167,7 +173,8 @@ export interface SystemStatusSummary {
     };
     draft: DraftStatusData;
     gameweekProcessing: {
-        currentGameweek: GameWeekData;
+        /** Absent for the same reasons as `SystemStatusSummary['currentGameweek']` above. */
+        currentGameweek: GameWeekData | undefined;
         lastProcessedGameweek: number;
         totalGameweeks: number;
         processedGameweeks: number[];

--- a/draft/app/teams/server/team.server.tsx
+++ b/draft/app/teams/server/team.server.tsx
@@ -52,14 +52,29 @@ export async function loadTeamData({ request, params }): Promise<TeamViewData> {
         // Get user's division
         const division = divisions.find((d) => d.id === currentUser.divisionId);
         if (!division) {
-            throw new Error('Division not found');
+            // The manager is assigned to a division the `Divisions` sheet does not list --
+            // a sheet mismatch, which nobody can act on from a bare "Division not found".
+            throw friendlyErrorResponse(
+                'This manager’s division is missing',
+                `${currentUser.userId} is assigned to “${currentUser.divisionId}”, which is not listed in the ` +
+                    'Divisions sheet. Add it there, or correct the manager’s division in UserTeams.',
+            );
         }
 
         // Get current team data from new division-teams structure
         const currentTeams = await getTeamsForGameweek(currentUser.divisionId, currentUser.userId, targetGameweek);
         if (!currentTeams) {
-            throw new Error(
-                `Current team data not found - division may not be set up yet. divisionId: ${currentUser.divisionId} user: ${currentUser.userId} `,
+            // Not a fault: the division genuinely has no `division-teams` document for this
+            // gameweek yet. It read as a crash ("Failed to load team data") because it was
+            // thrown as a bare Error, which sent people looking for a bug in the loader
+            // rather than at the admin step that has not been run.
+            console.info(
+                `No division-teams document for ${currentUser.divisionId} gw${targetGameweek} (user ${currentUser.userId})`,
+            );
+            throw friendlyErrorResponse(
+                'This team has not been set up yet',
+                `${division.label} has no squad data for gameweek ${targetGameweek}. ` +
+                    'An admin needs to commit teams for this division from Settings → Admin, then run points processing.',
             );
         }
 

--- a/draft/harness/dependency-alignment.test.ts
+++ b/draft/harness/dependency-alignment.test.ts
@@ -1,0 +1,67 @@
+/* Location: draft/harness/dependency-alignment.test.ts */
+
+/**
+ * The build workspace and the runtime workspace must agree on the packages the server
+ * bundle does not bundle.
+ *
+ * `draft` compiles the SSR bundle but leaves `react`, `react-dom/server` and `react-router`
+ * as external imports, so in production they resolve from `functions/node_modules` instead.
+ * Nothing checked that the two agreed, and they had drifted a long way:
+ *
+ *   package                draft (build)   functions (runtime)
+ *   react                  19.2.1          18.3.1
+ *   react-router           7.10.1          7.6.1
+ *   @react-router/node     7.10.1          7.18.1
+ *
+ * A bundle built against react-router 7.10.1 was therefore executed by 7.6.1, whose
+ * `singleFetchAction` still used the older `unstable_respond` protocol. Every fetcher
+ * submission on `/admin` came back `Error: Bad Request` — in production only, because
+ * every local mode runs the build workspace's own copies.
+ *
+ * Caret ranges are what let it drift: `functions` asked for `^7.0.0` and got whatever was
+ * newest whenever its lockfile last moved, while `draft` asked for `^7.10.1`. So this
+ * asserts both that the versions match and that they are pinned exactly.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Left external by the SSR build, so the runtime copy is the one that actually executes.
+ * Verified against `build/server/index.js`'s bare imports.
+ */
+const EXTERNALISED = ['react', 'react-dom', 'react-router', '@react-router/express', '@react-router/node'];
+
+const ROOT = join(import.meta.dirname, '..', '..');
+
+const declared = (workspace: string): Record<string, string> => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, workspace, 'package.json'), 'utf8'));
+    return { ...pkg.dependencies, ...pkg.devDependencies };
+};
+
+const draft = declared('draft');
+const functions = declared('functions');
+
+describe('the build and runtime workspaces agree on externalised packages', () => {
+    it.each(EXTERNALISED)('%s is declared at the same version in both workspaces', (name) => {
+        // Only meaningful where both declare it; a package one workspace does not use is fine.
+        if (!draft[name] || !functions[name]) return;
+
+        expect(functions[name], `functions must run the ${name} that draft builds against`).toBe(draft[name]);
+    });
+
+    it.each(EXTERNALISED)('%s is pinned exactly, not to a range', (name) => {
+        for (const [workspace, deps] of [
+            ['draft', draft],
+            ['functions', functions],
+        ] as const) {
+            const version = deps[name];
+            if (!version) continue;
+
+            expect(version, `${workspace} must pin ${name} exactly — a range lets the runtime drift`).toMatch(
+                /^\d+\.\d+\.\d+$/,
+            );
+        }
+    });
+});

--- a/draft/harness/server.mjs
+++ b/draft/harness/server.mjs
@@ -134,6 +134,20 @@ async function main() {
     const app = express();
     app.use(vite.middlewares);
     app.use(timeTravel(runWithNow));
+
+    // Firebase Functions parses the request body before the SSR handler ever runs, and that
+    // is not a detail -- it *consumes the stream*, so `@react-router/express` then builds a
+    // Request whose body is empty while its Content-Type still promises form data. Every
+    // action bug this project has hit lives in that gap.
+    //
+    // Without these the harness had `req.body === undefined` on every request, so the
+    // `getLoadContext: req => req.body` below passed undefined and no action behaved as it
+    // does live. It replicated the shape of production and not the behaviour, which is worse
+    // than not replicating it at all: it looked covered.
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.text());
+
     app.all(
         '*',
         createRequestHandler({

--- a/draft/package.json
+++ b/draft/package.json
@@ -21,8 +21,8 @@
     "dependencies": {
         "@firebase/database": "^1.1.0",
         "@googleapis/sheets": "13.0.2",
-        "@react-router/node": "^7.10.1",
-        "@react-router/serve": "^7.10.1",
+        "@react-router/node": "7.10.1",
+        "@react-router/serve": "7.10.1",
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-query-devtools": "^5.91.1",
         "clsx": "^2.1.1",
@@ -30,13 +30,13 @@
         "firebase": "^11.10.0",
         "firebase-admin": "^13.6.0",
         "isbot": "^5",
-        "react": "^19.2.1",
-        "react-dom": "^19.2.1",
-        "react-router": "^7.10.1"
+        "react": "19.2.1",
+        "react-dom": "19.2.1",
+        "react-router": "7.10.1"
     },
     "devDependencies": {
-        "@react-router/dev": "^7.10.1",
-        "@react-router/express": "^7.10.1",
+        "@react-router/dev": "7.10.1",
+        "@react-router/express": "7.10.1",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "7.0.0",
         "@testing-library/react": "16.3.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "functions",
-  "private": true,
-  "scripts": {
-    "build": "tsc",
-    "serve": "firebase emulators:start --only functions",
-    "shell": "firebase functions:shell",
-    "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
-  },
-  "engines": {
-    "node": "24.x",
-    "npm": "10.9.x"
-  },
-  "main": "lib/index.js",
-  "dependencies": {
-    "@googleapis/sheets": "13.0.2",
-    "@react-router/express": "^7.0.0",
-    "@react-router/node": "^7.9.4",
-    "@react-router/serve": "^7.0.0",
-    "@tanstack/react-query": "^5.85.5",
-    "@tanstack/react-query-devtools": "^5.85.5",
-    "clsx": "^2.1.1",
-    "date-fns": "^3.6.0",
-    "express": "^4.0.0",
-    "firebase": "^11.8.1",
-    "firebase-admin": "13.4.0",
-    "firebase-functions": "^6.3.2",
-    "isbot": "^5.1.28",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router": "^7.0.0"
-  },
-  "devDependencies": {
-    "@types/express": "^4.0.0",
-    "@types/node": "^24.0.0",
-    "typescript": "^5.8.3"
-  }
+    "name": "functions",
+    "private": true,
+    "scripts": {
+        "build": "tsc",
+        "serve": "firebase emulators:start --only functions",
+        "shell": "firebase functions:shell",
+        "deploy": "firebase deploy --only functions",
+        "logs": "firebase functions:log"
+    },
+    "engines": {
+        "node": "24.x",
+        "npm": "10.9.x"
+    },
+    "main": "lib/index.js",
+    "dependencies": {
+        "@googleapis/sheets": "13.0.2",
+        "@react-router/express": "7.10.1",
+        "@react-router/node": "7.10.1",
+        "@react-router/serve": "7.10.1",
+        "@tanstack/react-query": "^5.85.5",
+        "@tanstack/react-query-devtools": "^5.85.5",
+        "clsx": "^2.1.1",
+        "date-fns": "^3.6.0",
+        "express": "^4.0.0",
+        "firebase": "^11.8.1",
+        "firebase-admin": "13.4.0",
+        "firebase-functions": "^6.3.2",
+        "isbot": "^5.1.28",
+        "react": "19.2.1",
+        "react-dom": "19.2.1",
+        "react-router": "7.10.1"
+    },
+    "devDependencies": {
+        "@types/express": "^4.0.0",
+        "@types/node": "^24.0.0",
+        "typescript": "^5.8.3"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3472,7 +3472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-router/dev@npm:^7.10.1":
+"@react-router/dev@npm:7.10.1":
   version: 7.10.1
   resolution: "@react-router/dev@npm:7.10.1"
   dependencies:
@@ -3542,39 +3542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-router/express@npm:7.6.1, @react-router/express@npm:^7.0.0":
-  version: 7.6.1
-  resolution: "@react-router/express@npm:7.6.1"
-  dependencies:
-    "@react-router/node": "npm:7.6.1"
-  peerDependencies:
-    express: ^4.17.1 || ^5
-    react-router: 7.6.1
-    typescript: ^5.1.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/54f936a2c393807772711643fbb41758f7373ffaea59c92b5ffefb6df77f842116eb6fca6fcf75523a91bb661261a45777c3913c7a1875944d49099f9af6496d
-  languageName: node
-  linkType: hard
-
-"@react-router/express@npm:^7.10.1":
-  version: 7.18.2
-  resolution: "@react-router/express@npm:7.18.2"
-  dependencies:
-    "@react-router/node": "npm:7.18.2"
-  peerDependencies:
-    express: ^4.17.1 || ^5
-    react-router: 7.18.2
-    typescript: ^5.1.0 || ^6.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/0c5a4f557e28fd3bc683504129b1892c9790b3cb6422b77853a9bca2b905967e0727b77ed4f2de744627e0c8e397f5787fc3b9d8eed43afb1060007617ea3815
-  languageName: node
-  linkType: hard
-
-"@react-router/node@npm:7.10.1, @react-router/node@npm:^7.10.1":
+"@react-router/node@npm:7.10.1":
   version: 7.10.1
   resolution: "@react-router/node@npm:7.10.1"
   dependencies:
@@ -3589,74 +3557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-router/node@npm:7.18.2":
-  version: 7.18.2
-  resolution: "@react-router/node@npm:7.18.2"
-  dependencies:
-    "@mjackson/node-fetch-server": "npm:^0.2.0"
-  peerDependencies:
-    react-router: 7.18.2
-    typescript: ^5.1.0 || ^6.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/8dcd9cdb35322a13b975f278585f34403a3974f5e3ed7524c62825ec01c7865dc322a4f4650826919c06de26cdd32e2f21c95b609c340055abd41faba81c8f73
-  languageName: node
-  linkType: hard
-
-"@react-router/node@npm:7.6.1":
-  version: 7.6.1
-  resolution: "@react-router/node@npm:7.6.1"
-  dependencies:
-    "@mjackson/node-fetch-server": "npm:^0.2.0"
-    source-map-support: "npm:^0.5.21"
-    stream-slice: "npm:^0.1.2"
-    undici: "npm:^6.19.2"
-  peerDependencies:
-    react-router: 7.6.1
-    typescript: ^5.1.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/e9b9d7ea6e4e6a93ff8f5d9315ab2e0cee191f144d0440204e301adcf5d5c13e066b7d4c9352898e1bc24610600f1490e0be8d0d2585f8dad9bebd74354da20a
-  languageName: node
-  linkType: hard
-
-"@react-router/node@npm:^7.9.4":
-  version: 7.18.1
-  resolution: "@react-router/node@npm:7.18.1"
-  dependencies:
-    "@mjackson/node-fetch-server": "npm:^0.2.0"
-  peerDependencies:
-    react-router: 7.18.1
-    typescript: ^5.1.0 || ^6.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/46714e8c54ca4f0efefb87a14eebb0dc39d6c577291c2238298f921954fa24cb43506461f5af56f0673b6f54d84e1da4fbcb5c03ea837a9414f0d85997f2e75d
-  languageName: node
-  linkType: hard
-
-"@react-router/serve@npm:^7.0.0":
-  version: 7.6.1
-  resolution: "@react-router/serve@npm:7.6.1"
-  dependencies:
-    "@react-router/express": "npm:7.6.1"
-    "@react-router/node": "npm:7.6.1"
-    compression: "npm:^1.7.4"
-    express: "npm:^4.19.2"
-    get-port: "npm:5.1.1"
-    morgan: "npm:^1.10.0"
-    source-map-support: "npm:^0.5.21"
-  peerDependencies:
-    react-router: 7.6.1
-  bin:
-    react-router-serve: bin.js
-  checksum: 10/6913497a713d8e83c8dbbbbb6e53d2e2dd8df5f152929d0adfd7d4cac56c5e95a7b2c95250fc13f1c18ffdb9538b42c96fc6c498aa9caa423f144883f66540aa
-  languageName: node
-  linkType: hard
-
-"@react-router/serve@npm:^7.10.1":
+"@react-router/serve@npm:7.10.1":
   version: 7.10.1
   resolution: "@react-router/serve@npm:7.10.1"
   dependencies:
@@ -6156,10 +6057,10 @@ __metadata:
   dependencies:
     "@firebase/database": "npm:^1.1.0"
     "@googleapis/sheets": "npm:13.0.2"
-    "@react-router/dev": "npm:^7.10.1"
-    "@react-router/express": "npm:^7.10.1"
-    "@react-router/node": "npm:^7.10.1"
-    "@react-router/serve": "npm:^7.10.1"
+    "@react-router/dev": "npm:7.10.1"
+    "@react-router/express": "npm:7.10.1"
+    "@react-router/node": "npm:7.10.1"
+    "@react-router/serve": "npm:7.10.1"
     "@tanstack/react-query": "npm:^5.90.12"
     "@tanstack/react-query-devtools": "npm:^5.91.1"
     "@testing-library/dom": "npm:10.4.1"
@@ -6184,9 +6085,9 @@ __metadata:
     isbot: "npm:^5"
     knip: "npm:^5.71.0"
     msw: "npm:2.15.0"
-    react: "npm:^19.2.1"
-    react-dom: "npm:^19.2.1"
-    react-router: "npm:^7.10.1"
+    react: "npm:19.2.1"
+    react-dom: "npm:19.2.1"
+    react-router: "npm:7.10.1"
     remove-unused-vars: "npm:^0.0.11"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.9.3"
@@ -7604,9 +7505,9 @@ __metadata:
   resolution: "functions@workspace:functions"
   dependencies:
     "@googleapis/sheets": "npm:13.0.2"
-    "@react-router/express": "npm:^7.0.0"
-    "@react-router/node": "npm:^7.9.4"
-    "@react-router/serve": "npm:^7.0.0"
+    "@react-router/express": "npm:7.10.1"
+    "@react-router/node": "npm:7.10.1"
+    "@react-router/serve": "npm:7.10.1"
     "@tanstack/react-query": "npm:^5.85.5"
     "@tanstack/react-query-devtools": "npm:^5.85.5"
     "@types/express": "npm:^4.0.0"
@@ -7618,9 +7519,9 @@ __metadata:
     firebase-admin: "npm:13.4.0"
     firebase-functions: "npm:^6.3.2"
     isbot: "npm:^5.1.28"
-    react: "npm:^18.3.1"
-    react-dom: "npm:^18.3.1"
-    react-router: "npm:^7.0.0"
+    react: "npm:19.2.1"
+    react-dom: "npm:19.2.1"
+    react-router: "npm:7.10.1"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -8744,7 +8645,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
+"js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 10/af37d0d913fb56aec6dc0074c163cc71cd23c0b8aad5c2350747b6721d37ba118af35abdd8b33c47ec2800de07dedb16a527ca9c530ee004093e04958bd0cbf2
@@ -9204,17 +9105,6 @@ __metadata:
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
-  languageName: node
-  linkType: hard
-
-"loose-envify@npm:^1.1.0":
-  version: 1.4.0
-  resolution: "loose-envify@npm:1.4.0"
-  dependencies:
-    js-tokens: "npm:^3.0.0 || ^4.0.0"
-  bin:
-    loose-envify: cli.js
-  checksum: 10/6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
   languageName: node
   linkType: hard
 
@@ -10895,19 +10785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
-  peerDependencies:
-    react: ^18.3.1
-  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
-  languageName: node
-  linkType: hard
-
-"react-dom@npm:^19.2.1":
+"react-dom@npm:19.2.1":
   version: 19.2.1
   resolution: "react-dom@npm:19.2.1"
   dependencies:
@@ -10939,23 +10817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:^7.0.0":
-  version: 7.6.1
-  resolution: "react-router@npm:7.6.1"
-  dependencies:
-    cookie: "npm:^1.0.1"
-    set-cookie-parser: "npm:^2.6.0"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-  checksum: 10/90d3038db6d9c0d48bc932b8698c287a80759629ecef65f1ead32fadd78ef17895c7402832d3c94b47c45f10f8478b79551a647360415887f2f3a8fae10aca30
-  languageName: node
-  linkType: hard
-
-"react-router@npm:^7.10.1":
+"react-router@npm:7.10.1":
   version: 7.10.1
   resolution: "react-router@npm:7.10.1"
   dependencies:
@@ -10971,16 +10833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
-  languageName: node
-  linkType: hard
-
-"react@npm:^19.2.1":
+"react@npm:19.2.1":
   version: 19.2.1
   resolution: "react@npm:19.2.1"
   checksum: 10/7c7ab0f40b98e87e1466bea8c28564c5f3c384506cbda93d24788d32b40bf6059c991687c7e90a396b11f09223a779a81b1188af9acd839aaa0a672987c13107
@@ -11332,15 +11185,6 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10/7eaf7a0cf37cc27b42fb3ef6a9b1df6e93a1c6d98c6c6702b02fe262d5fcbd89db63320793b99b21cb5348097d0a53de81bd5f4e8b86e20cc9412e3f1cfb4e83
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
   languageName: node
   linkType: hard
 
@@ -11797,13 +11641,6 @@ __metadata:
   version: 1.0.3
   resolution: "stream-shift@npm:1.0.3"
   checksum: 10/a24c0a3f66a8f9024bd1d579a533a53be283b4475d4e6b4b3211b964031447bdf6532dd1f3c2b0ad66752554391b7c62bd7ca4559193381f766534e723d50242
-  languageName: node
-  linkType: hard
-
-"stream-slice@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "stream-slice@npm:0.1.2"
-  checksum: 10/6fa948ea58523f11f72e796f99579ff2bbecdff080d63b25762b0c0d282ac9a2d98af0f6e84dcc8d24c6284b2f7ce92ce0f9a1c8f77c91ac273954754e53c781
   languageName: node
   linkType: hard
 
@@ -12578,13 +12415,6 @@ __metadata:
   version: 8.3.0
   resolution: "undici-types@npm:8.3.0"
   checksum: 10/6681d2837ac75a75ac1cc46090aa2b8ddc7c6b8ecc295a6cdb06838752a730da3d8afeecf05e5ab7903160eafad3a8b6ffa1927e5ded260590f4d4fef18646d5
-  languageName: node
-  linkType: hard
-
-"undici@npm:^6.19.2":
-  version: 6.28.0
-  resolution: "undici@npm:6.28.0"
-  checksum: 10/672a7a53bd1f6c80edb73b357ab36e98ef9e474024c442aab2b8ea2bc32f1103cab05525c78661ae724f3e1340e23d03efb9730fba28e76218ab0ec52e15d75a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #120. The headline is the last one: **a react-router version skew between the build and runtime workspaces** was breaking every admin action in production, and only in production.

---

## The root cause of the populate failure

The server log finally gave it up:

```
Error: Bad Request
    at singleFetchAction (react-router/dist/development/chunk-ZA36QIGN.mjs:859:31)
    at handleSingleFetchRequest
```

`draft` builds the SSR bundle but leaves `react`, `react-dom/server` and `react-router` as **external** imports (confirmed in `build/server/index.js`), so in production they resolve from `functions/node_modules` instead. Nothing checked the two workspaces agreed, and they had drifted a long way:

| package | `draft` (build) | `functions` (runtime) |
|---|---|---|
| `react` | 19.2.1 | **18.3.1** |
| `react-dom` | 19.2.1 | **18.3.1** |
| `react-router` | 7.10.1 | **7.6.1** |
| `@react-router/express` | 7.18.2 | **7.6.1** |
| `@react-router/node` | 7.10.1 | **7.18.1** |

`functions` was not even self-consistent — `@react-router/node` 7.18.1 sitting next to `react-router` 7.6.1, a twelve-minor spread inside one runtime.

So a bundle built against react-router 7.10.1 was executed by 7.6.1, whose `singleFetchAction` still calls `staticHandler.query` with the older `unstable_respond` protocol rather than 7.10's `generateMiddlewareResponse`. Every fetcher submission to `/admin` failed that handshake and came back `Bad Request` — which is why it failed in production and worked in every local mode, since those all run the build workspace's own copies.

Caret ranges are what let it drift: `functions` asked for `^7.0.0` and got whatever was newest whenever its lockfile last moved. Both workspaces now pin the same exact versions, and `dependency-alignment.test.ts` fails if they diverge again *or* if either reverts to a range.

## The harness could never have caught it — and now catches the class beneath it

`harness/server.mjs` copied production's `getLoadContext: req => req.body` pass-through precisely so form actions would behave the same. But it had **no body parser**, so `req.body` was `undefined` on every request and that pass-through passed undefined every time. It replicated the *shape* of Firebase and not the *behaviour* — worse than not replicating it, because it looked covered.

Firebase parses the body before the handler runs, and doing so **consumes the stream**, so the Request `@react-router/express` builds has an empty body while its `Content-Type` still promises form data. The harness now parses the same way, closing the gap every action bug in this project has lived in.

---

## Also fixed

**`/teams` threw a bare `Error` for a division with no data.** A missing `division-teams` document is an expected state, but surfaced as "Failed to load team data" with the detail only in the server log. Now a friendly 503 naming the division, gameweek and admin step. Same for a manager whose division is not in the `Divisions` sheet.

| request | before | after |
|---|---|---|
| `/teams/Andy?gameweek=21` | 200 | 200, unchanged |
| `/teams/Andy?gameweek=999` | "Failed to load team data" | **503** — "This team has not been set up yet · Premier League has no squad data for gameweek 999…" |

**The admin status services invented a gameweek.** Both catch blocks substituted `{ fplEvent: { id: 1 } }`, so `/admin` reported "GW 1 needs processing" for a league with no calendar and no players — sending someone after a processing problem instead of an empty database. `currentGameweek` is now honestly optional and the pages say "No current gameweek".

**`/admin`'s loader had no try/catch at all** — the page whose job is diagnosing Sheets/FPL/Firestore gave the same opaque error when any of them failed. Now `loaderErrorResponse`.

**A background job failure could take the process down.** `throw new Error('🚨 Background job error:', error.message)` inside a `setTimeout` callback: reaches no caller, becomes an unhandled rejection, and the constructor was wrong anyway — the second argument is an options object, so the message was discarded.

**"Reset Database" could not finish, and cleared a stale list.** Batches of 10 with a 100ms sleep between them, plus reading every document id up front — 50× more round trips than Firestore's 500 limit needs, plus deliberate idling, comfortably past the 60s function timeout. Now batches of 400, no sleep, `.limit()` paging, and **resumable**: a pass stops at 25s and reports whether more remains, and the client repeats. Separately, `player-gameweeks` and `player_stats_cache` are orphans from an earlier version that appear nowhere in the codebase, so the hard-coded list never named them and every reset left them full — collections are now discovered via `listCollections()`.

> [!IMPORTANT]
> **Behaviour change:** reset now deletes *every* collection it finds, not four named ones. That is what the button already claims, but if anything in Firestore must survive a reset, say so and I will add an exclusion list.

---

## Testing

- `dependency-alignment.test.ts` — 10 tests pinning the build/runtime agreement that caused this.
- `firestore-memory.test.ts` — 5 new tests for `clearEverything` (orphans cleared, per-collection counts, exhausted budget reports `done: false`, large collection finishes across passes). The in-memory driver needed `listCollections()`; its collection reference had no `id`, which these caught immediately — it would have cleared nothing while reporting success.
- `overview-section.test.tsx` — 4 render tests, including "No current gameweek" rather than "GW 1".
- Verified against the fixture server with the pinned versions: every page 200, populate returns its summary, reset reports 121 documents across three collections.

`yarn test` 555 passing / 56 files (was 536 / 54) · `yarn ratchet` all four unchanged at baseline · `yarn build` clean.

Dependency changes are pins of existing packages, not additions.

## Not covered

`loadTeamData` still has no automated test — it needs the Sheets harness plus the in-memory Firestore, which is Part G's job. Verified through the fixture server instead, noted so it is not mistaken for coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)