### PR TITLE
refactor(harness): put fixture backends behind the seam, not in domain code

### DIFF
--- a/draft/app/_shared/lib/firestore-cache/firebase.admin.ts
+++ b/draft/app/_shared/lib/firestore-cache/firebase.admin.ts
@@ -1,3 +1,4 @@
+import { usingFixtureBackends } from '../fixture-backends';
 // app/_shared/lib/firestore-cache/firebase.admin.ts
 
 import { cert, getApp, getApps, initializeApp } from 'firebase-admin/app';
@@ -26,7 +27,7 @@ export function getFirestoreInstance() {
     if (!db) {
         // The offline test harness: no credentials, no network, no emulator. Set only by
         // `yarn dev:fixtures` and the harness tests -- see ./firestore-memory.ts.
-        if (process.env.KAMMY_FIXTURE_FIRESTORE === '1') {
+        if (usingFixtureBackends()) {
             console.log('🧪 Using the in-memory fixture Firestore (KAMMY_FIXTURE_FIRESTORE=1)');
             db = getInMemoryFirestore();
             return db;

--- a/draft/app/_shared/lib/firestore-cache/firebase.realtime-admin.ts
+++ b/draft/app/_shared/lib/firestore-cache/firebase.realtime-admin.ts
@@ -3,6 +3,8 @@
 import { cert, getApps, initializeApp } from 'firebase-admin/app';
 import type { Database } from 'firebase-admin/database';
 import { getDatabase } from 'firebase-admin/database';
+import { usingFixtureBackends } from '../fixture-backends';
+import { getInMemoryRealtimeDb } from './realtime-memory';
 
 // Use a unique app name for Realtime Database admin
 const REALTIME_ADMIN_APP_NAME = 'admin-realtime-draft';
@@ -39,7 +41,13 @@ function readServiceAccount(): Record<string, unknown> {
 // Get or create the Realtime Database app
 let realtimeDB: Database;
 
-export function getRealtimeAdminDbInstance() {
+export function getRealtimeAdminDbInstance(): Database {
+    // The seam. Callers get a database and never learn which one, exactly as
+    // `getFirestoreInstance()` does for Firestore.
+    if (usingFixtureBackends()) {
+        return getInMemoryRealtimeDb();
+    }
+
     if (!realtimeDB) {
         const existingApps = getApps();
 

--- a/draft/app/_shared/lib/firestore-cache/realtime-memory.ts
+++ b/draft/app/_shared/lib/firestore-cache/realtime-memory.ts
@@ -1,0 +1,184 @@
+/* Location: app/_shared/lib/firestore-cache/realtime-memory.ts */
+
+/**
+ * An in-memory Realtime Database, selected the same way the in-memory Firestore is.
+ *
+ * **It is never active in production.** `getRealtimeAdminDbInstance()` selects it only when
+ * `usingFixtureBackends()` is true, exactly as `getFirestoreInstance()` selects
+ * `firestore-memory.ts`. Callers get a database and know nothing about which one.
+ *
+ * This exists so that "we are running on fixtures" is answered in **one place, at the seam**,
+ * rather than by conditions spread through the app. The first version of the fixture support
+ * put a `process.env.KAMMY_FIXTURE_FIRESTORE` check inside `getAllDraftSyncComparisons()` --
+ * a domain service deciding what to do based on test infrastructure, which is the wrong shape
+ * and gets copied. With a driver behind the existing seam, the sync comparison just runs: it
+ * reads an empty database and reports no differences, which is the truth.
+ *
+ * Like the Firestore driver, it implements exactly the calls the app makes and throws on
+ * anything else, so a new call site is a loud failure rather than a silent empty read:
+ *
+ *   db.ref(path)                                  -- firebase-draft-sync.ts
+ *   ref.set(value) / .update(value) / .remove()
+ *   ref.push()                                    -- returns a child ref with a new key
+ *   ref.once('value')                             -- resolves to a snapshot
+ *   ref.orderByKey().limitToFirst(n).once('value')
+ *   snapshot.exists() / .val()
+ *
+ * Values go through a JSON round-trip on write, so shape drift surfaces as it would over the
+ * wire and a read cannot hand out a mutable reference into the store.
+ */
+
+type Node = Record<string, unknown>;
+
+const clone = <T>(value: T): T => (value === undefined ? value : (JSON.parse(JSON.stringify(value)) as T));
+
+const segmentsOf = (path: string): string[] => path.split('/').filter(Boolean);
+
+class MemoryRealtimeStore {
+    private root: Node = {};
+
+    read(path: string): unknown {
+        return segmentsOf(path).reduce<unknown>((node, segment) => {
+            if (node === null || typeof node !== 'object') return undefined;
+            return (node as Node)[segment];
+        }, this.root);
+    }
+
+    write(path: string, value: unknown): void {
+        const segments = segmentsOf(path);
+        if (segments.length === 0) {
+            this.root = (clone(value) as Node) ?? {};
+            return;
+        }
+
+        const last = segments.pop() as string;
+        let cursor = this.root;
+        for (const segment of segments) {
+            const next = cursor[segment];
+            cursor[segment] = next && typeof next === 'object' && !Array.isArray(next) ? (next as Node) : {};
+            cursor = cursor[segment] as Node;
+        }
+
+        if (value === null || value === undefined) {
+            delete cursor[last];
+            return;
+        }
+        cursor[last] = clone(value);
+    }
+
+    /** `update` merges at the top level of the target, as the real API does. */
+    merge(path: string, value: unknown): void {
+        const existing = this.read(path);
+        if (existing && typeof existing === 'object' && value && typeof value === 'object') {
+            this.write(path, { ...(existing as Node), ...(value as Node) });
+            return;
+        }
+        this.write(path, value);
+    }
+
+    clear(): void {
+        this.root = {};
+    }
+}
+
+class MemorySnapshot {
+    constructor(private readonly value: unknown) {}
+
+    exists(): boolean {
+        return this.value !== undefined && this.value !== null;
+    }
+
+    val(): unknown {
+        return clone(this.value);
+    }
+}
+
+/** `orderByKey()` and `limitToFirst()` narrow a read; nothing else is supported. */
+class MemoryQuery {
+    constructor(
+        protected readonly store: MemoryRealtimeStore,
+        protected readonly path: string,
+        private readonly ordered = false,
+        private readonly limit: number | null = null,
+    ) {}
+
+    orderByKey(): MemoryQuery {
+        return new MemoryQuery(this.store, this.path, true, this.limit);
+    }
+
+    limitToFirst(count: number): MemoryQuery {
+        return new MemoryQuery(this.store, this.path, this.ordered, count);
+    }
+
+    async once(eventType: string): Promise<MemorySnapshot> {
+        if (eventType !== 'value') {
+            throw new Error(`[fixture-realtime] unsupported event type: ${eventType}`);
+        }
+
+        const value = this.store.read(this.path);
+        if (!this.ordered && this.limit === null) return new MemorySnapshot(value);
+        if (!value || typeof value !== 'object') return new MemorySnapshot(value);
+
+        // Real RTDB orders children by key; sorting here is what makes a harness run
+        // reproducible, the same reason the Firestore driver orders by document id.
+        const entries = Object.entries(value as Node).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+        const limited = this.limit === null ? entries : entries.slice(0, this.limit);
+        return new MemorySnapshot(Object.fromEntries(limited));
+    }
+}
+
+class MemoryReference extends MemoryQuery {
+    private static pushCounter = 0;
+
+    async set(value: unknown): Promise<void> {
+        this.store.write(this.path, value);
+    }
+
+    async update(value: unknown): Promise<void> {
+        this.store.merge(this.path, value);
+    }
+
+    async remove(): Promise<void> {
+        this.store.write(this.path, null);
+    }
+
+    /**
+     * A child ref under a newly generated key.
+     *
+     * Real push ids sort chronologically; a zero-padded counter does too, which is all the
+     * `orderByKey()` read above depends on.
+     */
+    push(): MemoryReference {
+        MemoryReference.pushCounter += 1;
+        const key = `fixture-${String(MemoryReference.pushCounter).padStart(12, '0')}`;
+        return new MemoryReference(this.store, `${this.path}/${key}`);
+    }
+}
+
+class MemoryRealtimeDatabase {
+    readonly store = new MemoryRealtimeStore();
+
+    ref(path: string): MemoryReference {
+        return new MemoryReference(this.store, path);
+    }
+}
+
+/**
+ * The app types this as `firebase-admin`'s `Database`, and this implements a deliberate
+ * subset of it, so the structural types cannot line up. One cast, here.
+ */
+function asDatabase(instance: MemoryRealtimeDatabase): import('firebase-admin/database').Database {
+    return instance as unknown as import('firebase-admin/database').Database;
+}
+
+let singleton: MemoryRealtimeDatabase | undefined;
+
+export function getInMemoryRealtimeDb(): import('firebase-admin/database').Database {
+    if (!singleton) singleton = new MemoryRealtimeDatabase();
+    return asDatabase(singleton);
+}
+
+/** Drop everything. Call between scenarios so one does not leak into the next. */
+export function resetInMemoryRealtimeDb(): void {
+    singleton?.store.clear();
+}

--- a/draft/app/_shared/lib/fixture-backends.ts
+++ b/draft/app/_shared/lib/fixture-backends.ts
@@ -1,0 +1,22 @@
+/* Location: app/_shared/lib/fixture-backends.ts */
+
+/**
+ * One answer to "is this process running on fixture backends rather than real ones?".
+ *
+ * It exists so that question is asked **at the seams that construct a backend** — and
+ * nowhere else. `getFirestoreInstance()` and `getRealtimeAdminDbInstance()` read it to
+ * choose an implementation; everything above them gets a database and knows nothing about
+ * which one it got.
+ *
+ * That boundary is easy to erode. The first pass at supporting the fixture server put a
+ * `process.env.KAMMY_FIXTURE_FIRESTORE` check inside `getAllDraftSyncComparisons()` — a
+ * domain service branching on test infrastructure. It worked, and it was the wrong shape:
+ * the next service to hit the same problem copies it, and soon the condition is everywhere
+ * and the abstraction means nothing. If you find yourself importing this outside a backend
+ * constructor, the backend is missing a fixture implementation — add that instead.
+ *
+ * The variable is named for Firestore because that is the backend it was introduced for.
+ * It now selects every fixture backend; the name is kept because the harness, the docs and
+ * `.kiro/steering/architecture.md` all refer to it.
+ */
+export const usingFixtureBackends = (): boolean => process.env.KAMMY_FIXTURE_FIRESTORE === '1';

--- a/draft/app/admin/server/services/draft-sync-comparison.service.ts
+++ b/draft/app/admin/server/services/draft-sync-comparison.service.ts
@@ -9,21 +9,12 @@ import type { DraftSyncComparison, DraftSyncDifference, FirebaseDraftPick, Fireb
 /**
  * Get all draft sync comparisons for all divisions
  *
- * **Returns nothing under fixtures, and that is deliberate.** The comparison's whole job is
- * to check the Realtime Database against the sheets, and RTDB has no fixture and no
- * in-memory driver. Left to run, it reaches the real network — the one thing the fixture
- * server exists to avoid — and then hangs: `/admin` waits out its 12s timeout on every page
- * load, and `/api/admin/draft-sync-comparisons`, which calls this directly and has no
- * timeout at all, never returns. Both found by the route crawl.
- *
- * The guard lives here rather than in the two callers so a third cannot miss it.
+ * Knows nothing about fixtures. `getRealtimeAdminDbInstance()` decides which database this
+ * reads, so against fixtures it reads an empty one and reports no differences — which is
+ * the truth, not a special case. An earlier version branched on the fixture flag right
+ * here, which put test infrastructure inside a domain service.
  */
 export async function getAllDraftSyncComparisons(): Promise<DraftSyncComparison[]> {
-    if (process.env.KAMMY_FIXTURE_FIRESTORE === '1') {
-        console.log('⏭️  Skipping draft sync comparisons: no Realtime Database under fixtures');
-        return [];
-    }
-
     return await dataCache.get(CACHE_KEYS.DRAFT_SYNC.ALL_COMPARISONS, generateAllDraftSyncComparisons, {
         ttlMs: getCacheTTL(CACHE_KEYS.DRAFT_SYNC.ALL_COMPARISONS),
     });

--- a/draft/app/draft/server/firebase-draft-sync.test.ts
+++ b/draft/app/draft/server/firebase-draft-sync.test.ts
@@ -1,0 +1,138 @@
+/* Location: app/draft/server/firebase-draft-sync.test.ts */
+
+/**
+ * Lives here, not next to the driver in `_shared`, because `_shared` may not import a
+ * domain (architecture.test.ts, Rule 1) and `FirebaseDraftSync` is draft's. The Firestore
+ * driver's test says the same about the division-teams service.
+ *
+ * Exercised through `FirebaseDraftSync`, the app's own caller, for the same reason
+ * `firestore-memory.test.ts` goes through `FirestoreClient`: what matters is not that a
+ * nested object stores things, but that the real caller behaves the same against this
+ * driver as it does against the Realtime Database. A driver that passes its own unit tests
+ * while breaking its caller would be worse than nothing.
+ *
+ * The flag is read lazily inside `getRealtimeAdminDbInstance()`, so setting it here — before
+ * any test runs, after the imports — is what selects the in-memory driver.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { resetInMemoryRealtimeDb } from '../../_shared/lib/firestore-cache/realtime-memory';
+
+process.env.KAMMY_FIXTURE_FIRESTORE = '1';
+
+const DIVISION = 'premierLeague';
+
+// Imported after the flag is set, though the getter reads it lazily either way.
+let FirebaseDraftSync: typeof import('./firebase-draft-sync').FirebaseDraftSync;
+
+beforeAll(async () => {
+    ({ FirebaseDraftSync } = await import('./firebase-draft-sync'));
+});
+
+afterEach(() => {
+    resetInMemoryRealtimeDb();
+    FirebaseDraftSync.clearCache();
+});
+
+describe('the fixture Realtime Database, through FirebaseDraftSync', () => {
+    it('returns null for a draft state that was never written', async () => {
+        expect(await FirebaseDraftSync.getDraftState(DIVISION)).toBeNull();
+    });
+
+    it('reads back a draft state that was written', async () => {
+        await FirebaseDraftSync.updateDraftState(DIVISION, { isActive: true, currentPick: 4 });
+
+        const state = await FirebaseDraftSync.getDraftState(DIVISION);
+
+        expect(state).toMatchObject({ isActive: true, currentPick: 4 });
+    });
+
+    it('merges on update, leaving untouched fields alone', async () => {
+        await FirebaseDraftSync.updateDraftState(DIVISION, { isActive: true, currentPick: 4 });
+        FirebaseDraftSync.clearCache(); // the caller dedupes identical writes
+
+        await FirebaseDraftSync.updateDraftState(DIVISION, { currentPick: 5 });
+
+        const state = await FirebaseDraftSync.getDraftState(DIVISION);
+        expect(state).toMatchObject({ isActive: true, currentPick: 5 });
+    });
+
+    it('keeps divisions apart', async () => {
+        await FirebaseDraftSync.updateDraftState(DIVISION, { isActive: true });
+
+        expect(await FirebaseDraftSync.getDraftState('championship')).toBeNull();
+    });
+
+    it('does not hand out a live reference into the store', async () => {
+        await FirebaseDraftSync.updateDraftState(DIVISION, { isActive: true, currentPick: 1 });
+
+        const first = (await FirebaseDraftSync.getDraftState(DIVISION)) as { currentPick: number };
+        first.currentPick = 999;
+
+        expect(await FirebaseDraftSync.getDraftState(DIVISION)).toMatchObject({ currentPick: 1 });
+    });
+
+    it('removes the picks that are no longer valid, and keeps the ones that are', async () => {
+        await FirebaseDraftSync.updateDraftPick(DIVISION, 1, { playerCode: 111 });
+        await FirebaseDraftSync.updateDraftPick(DIVISION, 2, { playerCode: 222 });
+
+        await FirebaseDraftSync.removeOrphanedPicks(DIVISION, [1]);
+
+        // Read through the same seam the app uses rather than reaching into the driver.
+        const { getRealtimeAdminDbInstance } = await import(
+            '../../_shared/lib/firestore-cache/firebase.realtime-admin'
+        );
+        const snapshot = await getRealtimeAdminDbInstance().ref(`drafts/${DIVISION}/picks`).once('value');
+
+        expect(Object.keys(snapshot.val() ?? {})).toEqual(['1']);
+    });
+
+    it('appends events under generated keys and clears them again', async () => {
+        await FirebaseDraftSync.addDraftEvent(DIVISION, { type: 'pick-made', data: { pickNumber: 1 } } as never);
+        await FirebaseDraftSync.addDraftEvent(DIVISION, { type: 'turn-change', data: {} } as never);
+
+        const { getRealtimeAdminDbInstance } = await import(
+            '../../_shared/lib/firestore-cache/firebase.realtime-admin'
+        );
+        const eventsRef = getRealtimeAdminDbInstance().ref(`drafts/${DIVISION}/events`);
+
+        const before = await eventsRef.once('value');
+        expect(Object.keys(before.val() ?? {})).toHaveLength(2);
+
+        await FirebaseDraftSync.clearAllEvents(DIVISION);
+
+        expect((await eventsRef.once('value')).exists()).toBe(false);
+    });
+
+    it('orders keys so a read is reproducible', async () => {
+        // `cleanupOldEvents` reads with orderByKey().limitToFirst(), which is only meaningful
+        // if generated keys sort in insertion order.
+        for (let i = 0; i < 5; i++) {
+            await FirebaseDraftSync.addDraftEvent(DIVISION, { type: 'pick-made', data: { i } } as never);
+        }
+
+        const { getRealtimeAdminDbInstance } = await import(
+            '../../_shared/lib/firestore-cache/firebase.realtime-admin'
+        );
+        const snapshot = await getRealtimeAdminDbInstance()
+            .ref(`drafts/${DIVISION}/events`)
+            .orderByKey()
+            .limitToFirst(3)
+            .once('value');
+
+        const events = Object.values(snapshot.val() as Record<string, { data: { i: number } }>);
+        expect(events.map((event) => event.data.i)).toEqual([0, 1, 2]);
+    });
+
+    it('throws on an event type it does not implement, rather than reading nothing', async () => {
+        const { getRealtimeAdminDbInstance } = await import(
+            '../../_shared/lib/firestore-cache/firebase.realtime-admin'
+        );
+
+        await expect(
+            getRealtimeAdminDbInstance()
+                .ref('drafts')
+                .once('child_added' as never),
+        ).rejects.toThrow(/unsupported event type/);
+    });
+});


### PR DESCRIPTION
Addressing a fair criticism of #122: I had started stubbing backends *inside production code*, with the condition spreading rather than living at one boundary.

## What was wrong

`getFirestoreInstance()` already had the right shape — **one seam, swaps implementation on an env flag, callers know nothing**. But when the Realtime Database needed the same treatment, I did not follow it. Instead `getAllDraftSyncComparisons()` grew its own check:

```ts
if (process.env.KAMMY_FIXTURE_FIRESTORE === '1') {
    return [];   // a domain service branching on test infrastructure
}
```

That worked, and it was the wrong shape. The next service with the same problem copies it, and soon the condition is in five places and the abstraction means nothing.

## What it looks like now

The Realtime Database has a fixture driver behind the **existing** seam, exactly as Firestore does:

- **`realtime-memory.ts`** implements the nine calls `FirebaseDraftSync` actually makes — `ref`, `set`, `update`, `remove`, `push`, `once('value')`, `orderByKey`, `limitToFirst`, and a snapshot's `exists`/`val` — and **throws on anything else**, so a new call site is a loud failure rather than a silent empty read. Writes go through a JSON round-trip and generated keys sort chronologically, for the same reasons the Firestore driver does both.
- **`getRealtimeAdminDbInstance()`** selects it. Callers get a database and never learn which.
- **`getAllDraftSyncComparisons()` knows nothing about fixtures again.** It now *runs* against an empty database and reports no differences — which is the truth, not a special case.
- **`fixture-backends.ts`** holds the single check both seams read, and its header says plainly: if you are importing this outside a backend constructor, the backend is missing a fixture implementation — add that instead.

## What deliberately stays

The client-side `hasRealtimeConfig` guard in `firebase-client-config.ts` / `DraftFirebaseHandler`. That one is about **missing configuration**, not fixtures: without `VITE_FIREBASE_*` there is genuinely no database to talk to in the browser, and degrading is better production behaviour than a module-scope throw. It is not a test-infrastructure condition.

## Testing

`draft/app/draft/server/firebase-draft-sync.test.ts` — 9 tests through the app's own caller rather than the driver directly, matching how `firestore-memory.test.ts` goes through `FirestoreClient`. A driver that passes its own unit tests while breaking its caller would be worse than nothing.

It lives in `draft/` rather than beside the driver because **`_shared` may not import a domain** (`architecture.test.ts`, Rule 1) — the same reason the Firestore driver's division-teams coverage lives in `scoring/`. That test caught my first placement, which is exactly what it is for.

`yarn test` 564 passing / 57 files (was 555 / 56) · `yarn test:e2e` 84 passing, still credential-free · `yarn ratchet` unchanged · `yarn build` clean.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)